### PR TITLE
Update userdata partition size

### DIFF
--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
@@ -51,7 +51,7 @@ export RK_BOOTARGS_CMA_SIZE="48M"
 #export RK_PARTITION_CMD_IN_ENV="32K(env),512K@32K(idblock),256K(uboot),32M(boot),1G(rootfs),1G(oem),1G(userdata),-(media)"
 
 # export RK_PARTITION_CMD_IN_ENV="32K(env),512K@32K(idblock),256K(uboot_a),256K(uboot_b),256K(misc),32M(boot_a),32M(boot_b),512M(system_a),512M(system_b),256M(oem),-(userdata)"
-export RK_PARTITION_CMD_IN_ENV="32K(env),512K@32K(idblock),256K(uboot_a),256K(uboot_b),256K(misc),32M(boot_a),32M(boot_b),512M(system_a),512M(system_b),14152416K(userdata)"
+export RK_PARTITION_CMD_IN_ENV="32K(env),512K@32K(idblock),256K(uboot_a),256K(uboot_b),256K(misc),32M(boot_a),32M(boot_b),512M(system_a),512M(system_b),13640M(userdata)"
 # export RK_PARTITION_CMD_IN_ENV="32K(env),512K@32K(idblock),256K(uboot_a),256K(uboot_b),256K(misc),32M(boot_a),32M(boot_b),512M(system_a),512M(system_b),-(userdata)"
 
 # config partition's filesystem type (squashfs is readonly)


### PR DESCRIPTION
Some batches of Samsung 16G EMMC have a usable space of 14800MB instead of 14976MB we found in other batches. Thus the default size on the userdata need to be reduce to support them.