### PR TITLE
chore: fix minor build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output/*
 !IMAGE/.gitkeep
 !output/.gitkeep
 .BoardConfig.mk
+RK-RELEASE-NOTES-IPC.txt

--- a/project/build.sh
+++ b/project/build.sh
@@ -187,7 +187,7 @@ function choose_target_board()
 
 function build_select_board()
 {
-	RK_TARGET_BOARD_ARRAY=( $(cd ${TARGET_PRODUCT_DIR}/; ls BoardConfig*.mk BoardConfig_*/BoardConfig*.mk | sort) )
+	RK_TARGET_BOARD_ARRAY=( $(cd ${TARGET_PRODUCT_DIR}/; ls BoardConfig*.mk BoardConfig_*/BoardConfig*.mk 2>/dev/null | sort) )
 
 	RK_TARGET_BOARD_ARRAY_LEN=${#RK_TARGET_BOARD_ARRAY[@]}
 	if [ $RK_TARGET_BOARD_ARRAY_LEN -eq 0 ]; then

--- a/sysdrv/tools/board/e2fsprogs/Makefile
+++ b/sysdrv/tools/board/e2fsprogs/Makefile
@@ -16,6 +16,7 @@ all:
 	@test -f $(PKG_BIN)/usr/sbin/e2fsck || (\
 	rm -rf $(CURRENT_DIR)/$(PKG_NAME); \
 	tar -xf $(PKG_TARBALL); \
+	sed -i.bak -e 's|#define HAVE_SYS_TIME_H|#define HAVE_SYS_STAT_H\n#define HAVE_SYS_TIME_H|g' $(CURRENT_DIR)/$(PACKAGE_NAME)/util/subst.c
 	mkdir -p $(CURRENT_DIR)/$(PKG_NAME)/$(PKG_BIN); \
 	mkdir -p $(CURRENT_DIR)/$(PKG_BIN)/usr/; \
 	pushd $(CURRENT_DIR)/$(PKG_NAME)/; \


### PR DESCRIPTION
### Ignore invalid path selector BoardConfig*.mk

Better to ignore than to remove. Just a cosmetic change, this removes an error message that would be confusing.

```
[daniel@xps15 jetkvm-system]$ ./build.sh lunch BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
ls: cannot access 'BoardConfig*.mk': No such file or directory
BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
[build.sh:info] switching to board: /home/daniel/Projects/jetkvm-system/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
[build.sh:info] Running build_select_board succeeded.
```

### Ignore RK-RELEASE-NOTES-IPC.txt

Ignore symlink that results from building the solution.

### Fix util/subst.c not compiling

`HAVE_CONFIG_H` is not set, resulting in below error message. Source for e2fsprogs v1.43.9 here: https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/util/subst.c?h=v1.43.9

Compare this to more recent version of `util/subst.c` that also `#define HAVE_SYS_STAT_H` as part of the `else` fallback clause: https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/util/subst.c

This PR adds an in-line patch to align with the recent changes in e2fsprogs.

Alternatively:
- a more recent version of e2fsprogs could be used, 
- or the root cause on why `HAVE_CONFIG_H` is not set, when it is clearly defined in the `util/Makefile` generated by the `./configure` script, could be investigated (I could not find out why)

```
subst.c: In function 'main':
subst.c:391:29: error: implicit declaration of function 'fstat' [-Wimplicit-function-declaration]
  391 |                         if (fstat(fd, &stbuf) == 0) {
      |                             ^~~~~
subst.c:437:40: error: implicit declaration of function 'fchmod' [-Wimplicit-function-declaration]
  437 |                                 (void) fchmod(ofd, 0444);
      |                                        ^~~~~~
make[3]: *** [Makefile:329: subst.o] Error 1
make[2]: *** [Makefile:177: util/subst] Error 2
make[1]: *** [Makefile:16: all] Error 255
make[1]: Leaving directory '/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/e2fsprogs'
make: *** [/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/Makefile.tools.board.mk:73: board-build-e2fsprogs] Error 2
make: Leaving directory '/home/daniel/Projects/jetkvm-system/sysdrv'
[build.sh:error] Running build_rootfs failed!
[build.sh:error] exit code 2 from line 655:
[build.sh:info]     make rootfs -C ${SDK_SYSDRV_DIR}
```