### PR TITLE
chore: fix broken build for libnftnl (add libmnl as build dependency)

### DIFF
--- a/sysdrv/tools/board/nftables/Makefile
+++ b/sysdrv/tools/board/nftables/Makefile
@@ -29,7 +29,7 @@ NFT_CROSS_CFLAGS += -I$(DEPS_OUTPUT_DIR)/include/libnftl
 NFT_CROSS_LDFLAGS := $(SYSDRV_CROSS_CFLAGS)
 NFT_CROSS_LDFLAGS += -Wl,-rpath-link=$(DEPS_OUTPUT_DIR)/lib
 
-LIBMNL_CFLAGS := -I$(DEPS_OUTPUT_DIR)/include/libmnl
+LIBMNL_CFLAGS := -I$(DEPS_OUTPUT_DIR)/include
 LIBMNL_LIBS := -L$(DEPS_OUTPUT_DIR)/lib -lmnl -Wl,-rpath-link=$(DEPS_OUTPUT_DIR)/lib
 
 LIBNFTNL_CFLAGS := -I$(DEPS_OUTPUT_DIR)/include/libnftnl
@@ -63,9 +63,10 @@ libnftnl: libmnl
 	tar -xf $(LIBNFTNL_TARBALL); \
 	mkdir -p $(DEPS_OUTPUT_DIR); \
 	pushd $(CURRENT_DIR)/$(LIBNFTNL_NAME); \
-		echo "CFLAGS=$(SYSDRV_CROSS_CFLAGS)"; \
+		echo "CFLAGS=$(SYSDRV_CROSS_CFLAGS) LIBMNL_CFLAGS=$(LIBMNL_CFLAGS) LIBMNL_LIBS=$(LIBMNL_LIBS)"; \
 		./configure --host=$(SYSDRV_CROSS) --target=$(SYSDRV_CROSS) CFLAGS="$(SYSDRV_CROSS_CFLAGS)" \
-			LDFLAGS="$(SYSDRV_CROSS_CFLAGS)" --prefix=$(DEPS_OUTPUT_DIR) > /dev/null; \
+			LDFLAGS="$(SYSDRV_CROSS_CFLAGS)" LIBMNL_CFLAGS="$(LIBMNL_CFLAGS)" LIBMNL_LIBS="$(LIBMNL_LIBS)" \
+			--prefix=$(DEPS_OUTPUT_DIR) > /dev/null; \
 		make -j$(SYSDRV_JOBS) || (exit -1 && echo "Error building libnftnl"); \
 		make install; \
 		echo "Finished building libnftnl"; \


### PR DESCRIPTION
~/Projects/jetkvm-system/sysdrv/tools/board/nftables/libnftnl-1.2.8 ~/Projects/jetkvm-system/sysdrv/tools/board/nftables CFLAGS=-march=armv7-a -mfpu=neon -mfloat-abi=hard -march=armv7-a -mfpu=neon -mfloat-abi=hard configure: WARNING: using cross tools not prefixed with host triplet configure: error: Package requirements (libmnl >= 1.0.4) were not met:

Package 'libmnl', required by 'virtual:world', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you installed software in a non-standard prefix.

Alternatively, you may set the environment variables LIBMNL_CFLAGS and LIBMNL_LIBS to avoid the need to call pkg-config. See the pkg-config man page for more details.
make[2]: Entering directory '/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/nftables/libnftnl-1.2.8' make[2]: *** No targets specified and no makefile found.  Stop. make[2]: Leaving directory '/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/nftables/libnftnl-1.2.8' make[2]: Entering directory '/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/nftables/libnftnl-1.2.8' make[2]: *** No rule to make target 'install'.  Stop. make[2]: Leaving directory '/home/daniel/Projects/jetkvm-system/sysdrv/tools/board/nftables/libnftnl-1.2.8' Finished building libnftnl
~/Projects/jetkvm-system/sysdrv/tools/board/nftables