### PR TITLE
Add Entware installer

### DIFF
--- a/sysdrv/Makefile
+++ b/sysdrv/Makefile
@@ -453,7 +453,8 @@ rootfs_prepare: prepare
 	tar xfv $(SYSDRV_DIR)/tools/board/rootfs_script_struct.tar -C $(SYSDRV_DIR_OUT_ROOTFS)
 	cp -rf $(SYSDRV_DIR)/tools/board/rootfs/* $(SYSDRV_DIR_OUT_ROOTFS)
 	tar xjf $(TOOLCHAIN_DIR)/$(TOOLCHAIN_RUNTIME_LIB)/$(TOOLCHAIN_RUNTIME_LIB_C) -C $(SYSDRV_DIR_OUT_ROOTFS)
-	pushd $(SYSDRV_DIR_OUT_ROOTFS)/lib/ ; mv -fv \
+	wget -O $(SYSDRV_DIR_OUT_ROOTFS)/usr/sbin/entware-install.sh https://bin.entware.net/armv7sf-k3.2/installer/generic.sh
+	chmod +x $(SYSDRV_DIR_OUT_ROOTFS)/usr/sbin/entware-install.sh
 		libasan_preinit.o \
 		libasan.so* \
 		libtsan.so* \

--- a/sysdrv/Makefile
+++ b/sysdrv/Makefile
@@ -455,6 +455,7 @@ rootfs_prepare: prepare
 	tar xjf $(TOOLCHAIN_DIR)/$(TOOLCHAIN_RUNTIME_LIB)/$(TOOLCHAIN_RUNTIME_LIB_C) -C $(SYSDRV_DIR_OUT_ROOTFS)
 	wget -O $(SYSDRV_DIR_OUT_ROOTFS)/usr/sbin/entware-install.sh https://bin.entware.net/armv7sf-k3.2/installer/generic.sh
 	chmod +x $(SYSDRV_DIR_OUT_ROOTFS)/usr/sbin/entware-install.sh
+	pushd $(SYSDRV_DIR_OUT_ROOTFS)/lib/ ; mv -fv \
 		libasan_preinit.o \
 		libasan.so* \
 		libtsan.so* \


### PR DESCRIPTION
Running `entware-install.sh` adds full [Entware](https://github.com/Entware/Entware/wiki) package management functionality to the board using the `/opt/bin/opkg` command