### PR TITLE
Provide a way for persistent userdata init scripts

### DIFF
--- a/project/app/jetkvm/RkLunch-stop.sh
+++ b/project/app/jetkvm/RkLunch-stop.sh
@@ -22,6 +22,27 @@ rcK()
 				;;
 		esac
 	done
+
+	for i in /userdata/init.d/S??*;do
+
+		# Ignore dangling symlinks (if any).
+		[ ! -f "$i" ] && continue
+
+		case "$i" in
+			*.sh)
+				# Source shell script for speed.
+				(
+					trap - INT QUIT TSTP
+					set stop
+					. $i
+				)
+				;;
+			*)
+				# No sh extension, so fork subprocess.
+				$i stop
+				;;
+		esac
+	done
 }
 
 echo "Stop Application ..."

--- a/project/app/jetkvm/RkLunch.sh
+++ b/project/app/jetkvm/RkLunch.sh
@@ -24,6 +24,28 @@ rcS()
 				;;
 		esac
 	done
+
+  # Also allow for init scripts in userdata
+	for i in /userdata/init.d/S??* ;do
+
+		# Ignore dangling symlinks (if any).
+		[ ! -f "$i" ] && continue
+
+		case "$i" in
+			*.sh)
+				# Source shell script for speed.
+				(
+					trap - INT QUIT TSTP
+					set start
+					. $i
+				)
+				;;
+			*)
+				# No sh extension, so fork subprocess.
+				$i start
+				;;
+		esac
+	done
 }
 
 check_linker()


### PR DESCRIPTION
It would be helpful for deploying Tailscale via ssh if there were init scripts that could be persisted across firmware upgrades.

This would look for init scripts in `/userdata/init.d` and run them on start.