### PR TITLE
Improve TC358743 HDMI audio quality

### DIFF
--- a/sysdrv/source/kernel/drivers/media/i2c/tc35874x.c
+++ b/sysdrv/source/kernel/drivers/media/i2c/tc35874x.c
@@ -1096,19 +1096,18 @@ static void tc35874x_set_hdmi_audio(struct v4l2_subdev *sd)
 
 	/* Default settings from REF_02, sheet "Source HDMI" */
 	i2c_wr8(sd, FORCE_MUTE, 0x00);
-	i2c_wr8(sd, AUTO_CMD0, MASK_AUTO_MUTE7 | MASK_AUTO_MUTE6 |
-			MASK_AUTO_MUTE5 | MASK_AUTO_MUTE4 |
-			MASK_AUTO_MUTE1 | MASK_AUTO_MUTE0);
-	i2c_wr8(sd, AUTO_CMD1, MASK_AUTO_MUTE9);
+	/* Disable automatic audio muting to prevent ACR PLL unlock during silence */
+	i2c_wr8(sd, AUTO_CMD0, 0x00);
+	i2c_wr8(sd, AUTO_CMD1, 0x00);
 	i2c_wr8(sd, AUTO_CMD2, MASK_AUTO_PLAY3 | MASK_AUTO_PLAY2);
-	i2c_wr8(sd, BUFINIT_START, SET_BUFINIT_START_MS(500));
-	i2c_wr8(sd, FS_MUTE, 0x00);
+	i2c_wr8(sd, BUFINIT_START, SET_BUFINIT_START_MS(200));
+	i2c_wr8(sd, FS_MUTE, MASK_FS_NO_MUTE);
 	i2c_wr8(sd, FS_IMODE, MASK_NLPCM_SMODE | MASK_FS_SMODE);
 	i2c_wr8(sd, ACR_MODE, MASK_CTS_MODE);
-	i2c_wr8(sd, ACR_MDF0, MASK_ACR_L2MDF_1976_PPM | MASK_ACR_L1MDF_976_PPM);
-	i2c_wr8(sd, ACR_MDF1, MASK_ACR_L3MDF_3906_PPM);
-	i2c_wr8(sd, SDO_MODE1, MASK_SDO_FMT_I2S);
-	i2c_wr8(sd, DIV_MODE, SET_DIV_DLY_MS(100));
+	i2c_wr8(sd, ACR_MDF0, MASK_ACR_L2MDF_122_PPM | MASK_ACR_L1MDF_122_PPM);
+	i2c_wr8(sd, ACR_MDF1, MASK_ACR_L3MDF_244_PPM);
+	i2c_wr8(sd, SDO_MODE1, MASK_SDO_BIT_LENG_24BIT | MASK_SDO_FMT_I2S);
+	i2c_wr8(sd, DIV_MODE, SET_DIV_DLY_MS(600));
 
 	mutex_lock(&state->confctl_mutex);
 	i2c_wr16_and_or(sd, CONFCTL, 0xffff, MASK_AUDCHNUM_2 |
@@ -2222,8 +2221,8 @@ static int tc35874x_get_custom_ctrl(struct v4l2_ctrl *ctrl)
 	struct v4l2_subdev *sd = &state->sd;
 
 	if (ctrl->id == TC35874X_CID_AUDIO_SAMPLING_RATE) {
-		ret = get_audio_sampling_rate(sd);
-		*ctrl->p_new.p_s32 = ret;
+		*ctrl->p_new.p_s32 = get_audio_sampling_rate(sd);
+		return 0;  // Success
 	}
 
 	return ret;
@@ -2242,7 +2241,7 @@ static const struct v4l2_ctrl_config tc35874x_ctrl_audio_sampling_rate = {
 	.max = 768000,
 	.step = 1,
 	.def = 0,
-	.flags = V4L2_CTRL_FLAG_READ_ONLY,
+	.flags = V4L2_CTRL_FLAG_READ_ONLY | V4L2_CTRL_FLAG_VOLATILE,
 };
 
 static const struct v4l2_ctrl_config tc35874x_ctrl_audio_present = {

--- a/sysdrv/source/kernel/drivers/media/i2c/tc35874x_regs.h
+++ b/sysdrv/source/kernel/drivers/media/i2c/tc35874x_regs.h
@@ -606,6 +606,7 @@
 
 #define SDO_MODE1                             0x8652
 #define MASK_SDO_BIT_LENG                     0x70
+#define MASK_SDO_BIT_LENG_24BIT               0x30
 #define MASK_SDO_FMT                          0x03
 #define MASK_SDO_FMT_RIGHT                    0x00
 #define MASK_SDO_FMT_LEFT                     0x01


### PR DESCRIPTION
Optimize TC358743 audio capture to eliminate artifacts and improve audio fidelity:

- Disable automatic audio muting (AUTO_CMD0/AUTO_CMD1) to prevent ACR PLL instability during silence periods
- Reduce audio initialization delay from 500ms to 200ms for faster startup after HDMI format changes
- Disable sample rate-based muting (FS_MUTE) to prevent false muting
- Tighten ACR clock tolerance from 976/1976/3906 PPM to 122/122/244 PPM for 8-32x better audio clock tracking precision
- Increase divider settling time from 100ms to 600ms to eliminate artifacts during video resolution changes
- Explicitly configure 24-bit I2S sample depth
- Add V4L2_CTRL_FLAG_VOLATILE to audio_sampling_rate control to enable dynamic sample rate detection from userspace

These changes eliminate crackling and clipping artifacts during silence transitions and format changes, while providing significantly tighter audio clock synchronization with the HDMI source. The 122/244 PPM tolerance provides excellent audio quality while maintaining wide compatibility with consumer HDMI devices (typically 20-50 PPM crystal accuracy).

The sample rate detection capability allows userspace applications to query the actual HDMI audio sample rate via V4L2 ioctl, which is critical for supporting non-48kHz HDMI sources (e.g., 44.1kHz from Armbian SBC or other devices). This prevents sample rate mismatches that would cause audio distortion during resampling.