### PR TITLE
UVC streaming timeout and stability

### DIFF
--- a/sysdrv/source/kernel/arch/arm/boot/dts/rv1106-jetkvm-v2.dtsi
+++ b/sysdrv/source/kernel/arch/arm/boot/dts/rv1106-jetkvm-v2.dtsi
@@ -206,6 +206,11 @@
 	status = "okay";
 };
 
+/* Required for UAC1 + UVC gadget coexistence */
+&usbdrd_dwc3 {
+	tx-fifo-resize;
+};
+
 &crypto {
     status = "okay";
 };

--- a/sysdrv/source/kernel/drivers/usb/dwc3/gadget.c
+++ b/sysdrv/source/kernel/drivers/usb/dwc3/gadget.c
@@ -805,9 +805,10 @@ static int __dwc3_gadget_resize_tx_fifos(struct dwc3_ep *dep)
 		else
 			mult = dep->endpoint.mult;
 
-		mult = mult > 0 ? mult * 2 : 3;
-		if (mult > 6)
-			mult = 6;
+		/* Smaller multiplier to leave FIFO space for HID endpoints */
+		mult = mult > 0 ? mult : 3;
+		if (mult > 3)
+			mult = 3;
 	} else if (usb_endpoint_xfer_bulk(dep->endpoint.desc)) {
 		/*
 		 * Set enough tx fifos for Bulk endpoints to get

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/f_uvc.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/f_uvc.c
@@ -445,7 +445,9 @@ uvc_function_set_alt(struct usb_function *f, unsigned interface, unsigned alt)
 			memset(&v4l2_event, 0, sizeof(v4l2_event));
 			v4l2_event.type = UVC_EVENT_STREAMON;
 			v4l2_event_queue(&uvc->vdev, &v4l2_event);
-			return USB_GADGET_DELAYED_STATUS;
+			/* Complete immediately - DELAYED_STATUS causes 16s timeout */
+			uvc->state = UVC_STATE_STREAMING;
+			return 0;
 
 		default:
 			return -EINVAL;

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_queue.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_queue.c
@@ -44,12 +44,13 @@ static int uvc_queue_setup(struct vb2_queue *vq,
 {
 	struct uvc_video_queue *queue = vb2_get_drv_priv(vq);
 	struct uvc_video *video = container_of(queue, struct uvc_video, queue);
-#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
-	struct uvc_device *uvc = container_of(video, struct uvc_device, video);
-	struct f_uvc_opts *opts = fi_to_f_uvc_opts(uvc->func.fi);
-#endif
 	unsigned int req_size;
 	unsigned int nreq;
+#if defined(CONFIG_ARCH_ROCKCHIP) && defined(CONFIG_NO_GKI)
+	struct uvc_device *uvc = container_of(video, struct uvc_device, video);
+	struct f_uvc_opts *opts = uvc->func.fi ?
+		fi_to_f_uvc_opts(uvc->func.fi) : NULL;
+#endif
 
 	if (*nbuffers > UVC_MAX_VIDEO_BUFFERS)
 		*nbuffers = UVC_MAX_VIDEO_BUFFERS;
@@ -131,9 +132,13 @@ static void *uvc_buffer_mem_prepare(struct vb2_buffer *vb,
 {
 	struct uvc_video *video = container_of(queue, struct uvc_video, queue);
 	struct uvc_device *uvc = container_of(video, struct uvc_device, video);
-	struct f_uvc_opts *opts = fi_to_f_uvc_opts(uvc->func.fi);
+	struct f_uvc_opts *opts;
 	void *mem;
 
+	if (!uvc->func.fi)
+		return (vb2_plane_vaddr(vb, 0) + vb2_plane_data_offset(vb, 0));
+
+	opts = fi_to_f_uvc_opts(uvc->func.fi);
 	if (!opts->uvc_zero_copy || video->fcc == V4L2_PIX_FMT_YUYV)
 		return (vb2_plane_vaddr(vb, 0) + vb2_plane_data_offset(vb, 0));
 

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_v4l2.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_v4l2.c
@@ -200,29 +200,16 @@ uvc_v4l2_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
 	if (type != video->queue.queue.type)
 		return -EINVAL;
 
-	if (uvc->state != UVC_STATE_CONNECTED)
+	/* Allow STREAMON unless disconnected */
+	if (uvc->state == UVC_STATE_DISCONNECTED)
 		return -ENODEV;
 
-	/* Enable UVC video. */
 	ret = uvcg_video_enable(video, 1);
 	if (ret < 0)
 		return ret;
 
-	/*
-	 * Alt settings in an interface are supported only
-	 * for ISOC endpoints as there are different alt-
-	 * settings for zero-bandwidth and full-bandwidth
-	 * cases, but the same is not true for BULK endpoints,
-	 * as they have a single alt-setting.
-	 *
-	 * For ISOC endpoints, Complete the alternate setting
-	 * selection setup phase now that userspace is ready
-	 * to provide video frames.
-	 */
-	if (!usb_endpoint_xfer_bulk(video->ep->desc))
-		uvc_function_setup_continue(uvc);
-
-	uvc->state = UVC_STATE_STREAMING;
+	if (uvc->state != UVC_STATE_STREAMING)
+		uvc->state = UVC_STATE_STREAMING;
 
 	return 0;
 }

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_video.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_video.c
@@ -293,6 +293,9 @@ uvc_video_alloc_requests(struct uvc_video *video)
 
 	BUG_ON(video->req_size);
 
+	if (!video->ep->desc)
+		return -ENODEV;
+
 	if (!usb_endpoint_xfer_bulk(video->ep->desc)) {
 		req_size = video->ep->maxpacket
 			 * max_t(unsigned int, video->ep->maxburst, 1)

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_video.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/uvc_video.c
@@ -25,8 +25,12 @@
 static bool uvc_using_zero_copy(struct uvc_video *video)
 {
 	struct uvc_device *uvc = container_of(video, struct uvc_device, video);
-	struct f_uvc_opts *opts = fi_to_f_uvc_opts(uvc->func.fi);
+	struct f_uvc_opts *opts;
 
+	if (!uvc->func.fi)
+		return false;
+
+	opts = fi_to_f_uvc_opts(uvc->func.fi);
 	if (opts && opts->uvc_zero_copy && video->fcc != V4L2_PIX_FMT_YUYV)
 		return true;
 	else
@@ -399,15 +403,14 @@ static void uvcg_video_pump(struct work_struct *work)
 	return;
 }
 
-/*
- * Enable or disable the video stream.
- */
+/* Enable or disable the video stream. */
 int uvcg_video_enable(struct uvc_video *video, int enable)
 {
 	unsigned int i;
 	int ret;
 	struct uvc_device *uvc;
 	struct f_uvc_opts *opts;
+	int pm_qos_latency;
 
 	if (video->ep == NULL) {
 		uvcg_info(&video->uvc->func,
@@ -416,7 +419,15 @@ int uvcg_video_enable(struct uvc_video *video, int enable)
 	}
 
 	uvc = container_of(video, struct uvc_device, video);
-	opts = fi_to_f_uvc_opts(uvc->func.fi);
+
+	/* fi may be NULL during disconnect */
+	if (uvc->func.fi) {
+		opts = fi_to_f_uvc_opts(uvc->func.fi);
+		pm_qos_latency = opts->pm_qos_latency;
+	} else {
+		opts = NULL;
+		pm_qos_latency = PM_QOS_DEFAULT_VALUE;
+	}
 
 	if (!enable) {
 		cancel_work_sync(&video->pump);
@@ -433,7 +444,7 @@ int uvcg_video_enable(struct uvc_video *video, int enable)
 		return 0;
 	}
 
-	cpu_latency_qos_add_request(&uvc->pm_qos, opts->pm_qos_latency);
+	cpu_latency_qos_add_request(&uvc->pm_qos, pm_qos_latency);
 	if ((ret = uvcg_queue_enable(&video->queue, 1)) < 0)
 		return ret;
 


### PR DESCRIPTION
## Summary

  Fixes UVC gadget streaming issues that prevented reliable camera passthrough on RV1106.

  ## Problems Solved

  1. **16-second streaming timeout**: Host would timeout waiting for USB SET_INTERFACE response
  2. **Kernel panic on disconnect**: NULL pointer dereference when USB cable unplugged during streaming
  3. **FIFO exhaustion**: UVC + UAC1 + HID gadgets couldn't coexist due to insufficient FIFO allocation
  4. **Failed stream restart**: STREAMON rejected when host re-negotiated format

  ## Changes

  ### Device Tree (`rv1106-jetkvm-v2.dtsi`)
  - Enable `tx-fifo-resize` for DWC3 controller to allow dynamic FIFO allocation

  ### DWC3 Driver (`gadget.c`)
  - Reduce isochronous FIFO multiplier from 6x to 3x to leave space for HID endpoints
  - Original: `mult = mult > 0 ? mult * 2 : 3` capped at 6
  - Fixed: `mult = mult > 0 ? mult : 3` capped at 3

  ### UVC Function (`f_uvc.c`)
  - Complete SET_INTERFACE immediately instead of returning `USB_GADGET_DELAYED_STATUS`
  - Set state to `UVC_STATE_STREAMING` synchronously

  ### UVC Queue (`uvc_queue.c`)
  - Add NULL check for `uvc->func.fi` before dereferencing in `uvc_queue_setup()` and `uvc_buffer_mem_prepare()`

  ### UVC Video (`uvc_video.c`)
  - Add NULL check for `uvc->func.fi` in `uvc_using_zero_copy()` and `uvcg_video_enable()`
  - Use `PM_QOS_DEFAULT_VALUE` as fallback when `func.fi` is NULL

  ### UVC V4L2 (`uvc_v4l2.c`)
  - Allow `STREAMON` when state is `STREAMING` (was only allowed in `CONNECTED`)
  - Remove `uvc_function_setup_continue()` call (handled by f_uvc.c now)