### PR TITLE
tun: fix NULL pointer dereference race in tun_get()

### DIFF
--- a/sysdrv/source/kernel/drivers/net/tun.c
+++ b/sysdrv/source/kernel/drivers/net/tun.c
@@ -860,11 +860,17 @@ out:
 static struct tun_struct *tun_get(struct tun_file *tfile)
 {
 	struct tun_struct *tun;
+	struct net_device *dev;
 
 	rcu_read_lock();
 	tun = rcu_dereference(tfile->tun);
-	if (tun)
-		dev_hold(tun->dev);
+	if (tun) {
+		dev = READ_ONCE(tun->dev);
+		if (dev && dev->reg_state == NETREG_REGISTERED)
+			dev_hold(dev);
+		else
+			tun = NULL;
+	}
 	rcu_read_unlock();
 
 	return tun;


### PR DESCRIPTION
The tun_get() function has a race condition where tun->dev can become NULL between checking tun and calling dev_hold(tun->dev).

This occurs when tun_detach_all() runs concurrently:
1. tun_get() calls rcu_dereference(tfile->tun), gets valid tun
2. Another thread calls tun_detach_all() which sets tun->dev to NULL
3. dev_hold(tun->dev) dereferences NULL pointer -> kernel crash

Fix by reading tun->dev into a local variable with READ_ONCE() and verifying both the pointer and device registration state before taking the reference.

Crash signature:
  Unable to handle kernel NULL pointer dereference at virtual address 00000004
  PC is at tun_get+0x16/0x22 [tun]