### PR TITLE
feat(usb): gadget: f_hid: add wakeup_on_write support

### DIFF
--- a/sysdrv/source/kernel/drivers/usb/gadget/function/f_hid.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/f_hid.c
@@ -432,7 +432,6 @@ static ssize_t f_hidg_write(struct file *file, const char __user *buffer,
 			    size_t count, loff_t *offp)
 {
 	struct f_hidg *hidg  = file->private_data;
-	struct usb_composite_dev *cdev = hidg->func.config->cdev;
 	struct usb_request *req;
 	unsigned long flags;
 	ssize_t status = -ENOMEM;
@@ -444,8 +443,11 @@ static ssize_t f_hidg_write(struct file *file, const char __user *buffer,
 	 * configuration descriptor).  If the UDC or the host does not support
 	 * wakeup the call simply returns an error we can safely ignore.
 	 */
-	if (hidg->wakeup_on_write && cdev && cdev->gadget)
-		usb_gadget_wakeup(cdev->gadget);
+	if (hidg->wakeup_on_write && hidg->func.config) {
+		struct usb_composite_dev *cdev = hidg->func.config->cdev;
+		if (cdev && cdev->gadget)
+			usb_gadget_wakeup(cdev->gadget);
+	}
 
 	spin_lock_irqsave(&hidg->write_spinlock, flags);
 

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/f_hid.c
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/f_hid.c
@@ -54,6 +54,8 @@ struct f_hidg {
 	 *              will be used to receive reports.
 	 */
 	bool				use_out_ep;
+	/* attempt to wake the host when writing a report */
+	bool				wakeup_on_write;
 
 	/* recv report */
 	spinlock_t			read_spinlock;
@@ -430,9 +432,20 @@ static ssize_t f_hidg_write(struct file *file, const char __user *buffer,
 			    size_t count, loff_t *offp)
 {
 	struct f_hidg *hidg  = file->private_data;
+	struct usb_composite_dev *cdev = hidg->func.config->cdev;
 	struct usb_request *req;
 	unsigned long flags;
 	ssize_t status = -ENOMEM;
+
+	/*
+	 * Try to wake the host if it suspended the bus.  The wakeup request
+	 * is only honoured when the host has negotiated remote-wakeup during
+	 * enumeration (indicated by the bmAttributes remote-wakeup bit in the
+	 * configuration descriptor).  If the UDC or the host does not support
+	 * wakeup the call simply returns an error we can safely ignore.
+	 */
+	if (hidg->wakeup_on_write && cdev && cdev->gadget)
+		usb_gadget_wakeup(cdev->gadget);
 
 	spin_lock_irqsave(&hidg->write_spinlock, flags);
 
@@ -1097,6 +1110,7 @@ CONFIGFS_ATTR(f_hid_opts_, name)
 F_HID_OPT(subclass, 8, 255);
 F_HID_OPT(protocol, 8, 255);
 F_HID_OPT(no_out_endpoint, 8, 1);
+F_HID_OPT(wakeup_on_write, 8, 1);
 F_HID_OPT(report_length, 16, 65535);
 
 static ssize_t f_hid_opts_report_desc_show(struct config_item *item, char *page)
@@ -1157,6 +1171,7 @@ static struct configfs_attribute *hid_attrs[] = {
 	&f_hid_opts_attr_subclass,
 	&f_hid_opts_attr_protocol,
 	&f_hid_opts_attr_no_out_endpoint,
+	&f_hid_opts_attr_wakeup_on_write,
 	&f_hid_opts_attr_report_length,
 	&f_hid_opts_attr_report_desc,
 	&f_hid_opts_attr_dev,
@@ -1297,6 +1312,7 @@ static struct usb_function *hidg_alloc(struct usb_function_instance *fi)
 		}
 	}
 	hidg->use_out_ep = !opts->no_out_endpoint;
+	hidg->wakeup_on_write = opts->wakeup_on_write;
 
 	mutex_unlock(&opts->lock);
 

--- a/sysdrv/source/kernel/drivers/usb/gadget/function/u_hid.h
+++ b/sysdrv/source/kernel/drivers/usb/gadget/function/u_hid.h
@@ -21,6 +21,7 @@ struct f_hid_opts {
 	unsigned char			subclass;
 	unsigned char			protocol;
 	unsigned char			no_out_endpoint;
+	unsigned char			wakeup_on_write;
 	unsigned short			report_length;
 	unsigned short			report_desc_length;
 	unsigned char			*report_desc;


### PR DESCRIPTION
### Summary

Add a `wakeup_on_write` configfs attribute to the USB HID gadget function driver (`f_hid`). When enabled, the driver calls `usb_gadget_wakeup()` before writing each HID report, allowing the gadget to wake a suspended host via USB remote wakeup.

This is the kernel-side prerequisite for USB remote wakeup on JetKVM. The companion Go app change sets `bmAttributes = 0xa0` and enables `wakeup_on_write` on all HID functions during gadget setup. The Go app side changed, required to make this feature work end to end, are at https://github.com/jetkvm/kvm/pull/1235.

Related: jetkvm/kvm#120, jetkvm/kvm#674.

### How it works

- New `wakeup_on_write` boolean attribute in the HID function's configfs directory
- Default: `0` (off). Must be set to `1` before the function is allocated (same lifecycle as `no_out_endpoint`)
- When enabled, `f_hidg_write()` calls `usb_gadget_wakeup()` at the top of each write. If the host hasn't negotiated remote wakeup or the bus isn't suspended, the call returns an error that is safely ignored
- Zero impact on existing behavior when disabled

### Changes

- `f_hid.c`: Add `wakeup_on_write` field to `f_hidg`, call `usb_gadget_wakeup()` in `f_hidg_write()`, register configfs attribute via `F_HID_OPT` macro
- `u_hid.h`: Add `wakeup_on_write` field to `f_hid_opts`

### Testing

Tested on JetKVM v2 (RV1106, DWC3 v3.30a, kernel 5.10.160). Host: Windows 11 (S3 sleep), Intel Z390 xHCI.

1. `wakeup_on_write` attribute appears in configfs for all HID functions
2. Host enumerates with remote wakeup capability (`bmAttributes = 0xa0`)
3. Host enters S3 sleep, USB link enters L2 suspend
4. HID write triggers `usb_gadget_wakeup()` → DWC3 sends Recovery on the bus → host wakes
5. `powercfg /lastwake` confirms wake source: Intel USB 3.1 eXtensible Host Controller

More testing details at https://github.com/jetkvm/kvm/pull/1235.