### PR TITLE
fix: set FT5x06 touchscreen threshold to reduce phantom touch events

### DIFF
--- a/sysdrv/source/kernel/arch/arm/boot/dts/rv1106g-jetkvm-v2.dts
+++ b/sysdrv/source/kernel/arch/arm/boot/dts/rv1106g-jetkvm-v2.dts
@@ -129,6 +129,7 @@
 		reset-gpios = <&gpio2 RK_PA3 GPIO_ACTIVE_LOW>;
 		touchscreen-size-x = <240>;
 		touchscreen-size-y = <300>;
+		threshold = <40>;
 		touch_type = <1>;
  	};
 };


### PR DESCRIPTION
## Summary

- Sets `threshold = <40>` on the FT5x06 touchscreen device tree node
- The edt-ft5406 driver was left at the chip's hardware default of 0 (zero noise rejection), making it susceptible to phantom touch events from EMI or power supply ripple
- Users report the device randomly opening the Settings screen without physical interaction (~1-2x/day)

Fixes https://github.com/jetkvm/kvm/issues/552

## Notes

- Threshold value of 40 is a starting point — may need tuning based on field feedback
- We confirmed via sysfs that the current threshold is 0 on production devices
- Runtime sysfs writes to the threshold register are accepted but not retained by the chip, so this device tree change (applied at probe time) is the correct fix path
- Could not reproduce phantom touches in a controlled environment (EMI-dependent), but the misconfiguration is confirmed

## Test plan

- [ ] Build system image with this change
- [ ] Verify threshold reads as 40 via `cat /sys/devices/platform/ff460000.i2c/i2c-3/3-0015/threshold`
- [ ] Deploy to a device that exhibits phantom touches and monitor over 24-48h
- [ ] Verify normal touch responsiveness is unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single device-tree parameter tweak with localized impact to touchscreen filtering; low risk aside from potential sensitivity/UX tuning needs on some panels.
> 
> **Overview**
> Updates the JetKVM v2 device tree (`rv1106g-jetkvm-v2.dts`) to configure the FT5x06 (`edt-ft5406`) touchscreen with a non-default `threshold = <40>` at probe time.
> 
> This raises touch noise rejection to help prevent phantom touch events without changing any other hardware configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c817c865ea89e00030a3136da3b8d70c96387fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->