### PR TITLE
e2e: add JETKVM_REMOTE_HOST support and preflight connectivity checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION_DEV := $(VERSION)-dev$(shell date -u +%Y%m%d%H%M)
 DEVICE_IP ?= 192.168.1.77
 R2_PATH := r2://jetkvm-update/system
 
-.PHONY: build flash test dev_release release bump-version git_check_dev clean
+.PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote
 
 # -----------------------------------------------------------------------------
 # Git checks
@@ -40,11 +40,28 @@ git_check_dev:
 build: clean
 	./scripts/build_system.sh
 
-flash: build
+check_device:
+	@echo "Checking device connectivity ($(DEVICE_IP))..."
+	@ping -c 1 -W 5 $(DEVICE_IP) > /dev/null 2>&1 || { echo "Error: Cannot reach device at $(DEVICE_IP)"; exit 1; }
+	@ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@$(DEVICE_IP) "echo ok" > /dev/null 2>&1 || { echo "Error: SSH failed to root@$(DEVICE_IP)"; exit 1; }
+	@echo "OK: Device reachable"
+
+check_remote:
+	@echo "Checking remote host connectivity ($(JETKVM_REMOTE_HOST))..."
+	@ping -c 1 -W 5 $(JETKVM_REMOTE_HOST) > /dev/null 2>&1 || { echo "Error: Cannot reach remote host at $(JETKVM_REMOTE_HOST)"; exit 1; }
+	@ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=10 root@$(JETKVM_REMOTE_HOST) "echo ok" > /dev/null 2>&1 || { echo "Error: SSH failed to root@$(JETKVM_REMOTE_HOST)"; exit 1; }
+	@echo "OK: Remote host reachable"
+
+flash:
+	$(MAKE) check_device
+	$(MAKE) build
 	./scripts/flash_system.sh -r $(DEVICE_IP)
 
-test: flash
-	./scripts/run_e2e_tests.sh -r $(DEVICE_IP)
+test:
+	$(MAKE) check_device
+	$(MAKE) check_remote
+	$(MAKE) flash
+	./scripts/run_e2e_tests.sh -r $(DEVICE_IP) --remote-host $(JETKVM_REMOTE_HOST)
 
 # -----------------------------------------------------------------------------
 # Dev Release - Prerelease for testing

--- a/scripts/flash_system.sh
+++ b/scripts/flash_system.sh
@@ -51,8 +51,8 @@ if [ ! -f "$ota_tar" ]; then
     exit 1
 fi
 
-msg_info ">> Flashing system image to device..."
-msg_info "  Transferring update_ota.tar to /userdata/jetkvm/update_system.tar......"
+msg_info ">> Flashing system image to ${DEVICE_USER}@${DEVICE_IP}..."
+msg_info "  Transferring update_ota.tar to /userdata/jetkvm/update_system.tar..."
 sshdev "cat > /userdata/jetkvm/update_system.tar" < "$ota_tar"
 msg_ok "  OK: Transfer complete"
 

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -8,6 +8,8 @@ DEVICE_IP="${DEVICE_IP:-192.168.1.77}"
 DEVICE_USER="${DEVICE_USER:-root}"
 KVM_REPO="${KVM_REPO:-https://github.com/jetkvm/kvm.git}"
 KVM_BRANCH="${KVM_BRANCH:-dev}"
+JETKVM_REMOTE_HOST="${JETKVM_REMOTE_HOST:-}"
+
 KVM_DIR=""
 TEMP_DIR=""
 
@@ -21,6 +23,7 @@ show_help() {
     echo "  -u, --user <user>     Remote username (default: ${DEVICE_USER})"
     echo "      --kvm-dir <path>  Path to existing kvm repo (skips clone)"
     echo "      --kvm-branch <b>  KVM branch to clone (default: ${KVM_BRANCH})"
+    echo "      --remote-host <h> Remote host for remote-agent tests (required)"
     echo "  --help               Show this help message"
     echo
 }
@@ -55,6 +58,10 @@ while [[ $# -gt 0 ]]; do
             KVM_BRANCH="$2"
             shift 2
             ;;
+        --remote-host)
+            JETKVM_REMOTE_HOST="$2"
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -67,8 +74,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-check_ping "${DEVICE_IP}"
-check_ssh "${DEVICE_USER}" "${DEVICE_IP}"
+if [ -z "$JETKVM_REMOTE_HOST" ]; then
+    msg_err "Error: JETKVM_REMOTE_HOST is required (set via --remote-host or env var)"
+    show_help
+    exit 1
+fi
 
 if [ -z "$KVM_DIR" ]; then
     TEMP_DIR=$(mktemp -d)
@@ -82,6 +92,6 @@ fi
 
 cd "$KVM_DIR"
 msg_info ">> Running E2E tests (this deploys the app)..."
-make frontend
-make test_e2e DEVICE_IP="$DEVICE_IP"
+
+make test_e2e DEVICE_IP="$DEVICE_IP" JETKVM_REMOTE_HOST="$JETKVM_REMOTE_HOST"
 msg_ok "OK: E2E tests passed"


### PR DESCRIPTION
## Summary
- Add required `JETKVM_REMOTE_HOST` variable for E2E tests, passed through to `make test_e2e` in the kvm repo
- Add `check_device` / `check_remote` Makefile targets that verify ping + SSH connectivity before starting the build, so you fail fast instead of waiting for a full build cycle
- Remove redundant `make frontend` call in `run_e2e_tests.sh` (already handled inside `test_e2e`)
- Show target device IP/user in flash output for visibility

## Test plan
- [ ] `make flash DEVICE_IP=<ip>` — should check device connectivity, then build and flash (no `JETKVM_REMOTE_HOST` required)
- [ ] `make test DEVICE_IP=<ip> JETKVM_REMOTE_HOST=<host>` — should check both hosts, build, flash, and run E2E
- [ ] Verify unreachable IP fails fast before build starts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `make test`/E2E invocation contract by requiring `JETKVM_REMOTE_HOST`, which can break existing automation, and adds new preflight SSH/ping checks that may cause earlier failures in some environments.
> 
> **Overview**
> E2E testing now **requires** a `JETKVM_REMOTE_HOST` value and threads it through `make test` to `scripts/run_e2e_tests.sh`, which enforces the flag/env var and passes it into the downstream `kvm` repo’s `make test_e2e`.
> 
> The Makefile adds `check_device`/`check_remote` preflight targets (ping + SSH) and wires them into `flash` and `test` so connectivity issues fail fast before long build/flash cycles. Minor UX tweaks include removing a redundant `make frontend` step during E2E and improving flash logs to include the target `${DEVICE_USER}@${DEVICE_IP}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e2261940e041ac9a13f68994050d63e6f7f9766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->