### PR TITLE
feat: add ref-based release and test workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,25 @@
 #   dev_release  - Dev release (prerelease) with testing
 #   release      - Production release with testing
 #   bump-version - Bump version for next release cycle
+#
+# Optional ref-based workflows (commit, tag, or branch):
+#   RELEASE_REF=<git-ref>   make test / dev_release / release from that ref (uses temporary worktrees)
+#   ALLOW_DIRTY=1           skip the clean-worktree guard for ref-based helpers
 
 VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
 VERSION_DEV := $(VERSION)-dev$(shell date -u +%Y%m%d%H%M)
+RELEASE_REF ?=
+BUILD_VERSION ?=
+ALLOW_DIRTY ?=
+BUILD_BOARD_CONFIG ?= BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
 
 DEVICE_IP ?= 192.168.1.77
 R2_PATH := r2://jetkvm-update/system
+
+# Environment forwarded to scripts/release_from_ref.sh and scripts/test_from_ref.sh
+REF_WORKFLOW_ENVS := DEVICE_IP="$(DEVICE_IP)" DEVICE_USER="$(DEVICE_USER)" JETKVM_REMOTE_HOST="$(JETKVM_REMOTE_HOST)" KVM_DIR="$(KVM_DIR)" KVM_BRANCH="$(KVM_BRANCH)" KVM_REPO="$(KVM_REPO)" SKIP_BUILD="$(SKIP_BUILD)" ALLOW_DIRTY="$(ALLOW_DIRTY)" BUILD_BOARD_CONFIG="$(BUILD_BOARD_CONFIG)"
+RELEASE_FROM_REF_ENVS := $(REF_WORKFLOW_ENVS) R2_PATH="$(R2_PATH)"
+TEST_FROM_REF_ENVS := $(REF_WORKFLOW_ENVS) BUILD_VERSION="$(BUILD_VERSION)"
 
 .PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote
 
@@ -59,6 +72,7 @@ ifndef SKIP_BUILD
 endif
 	./scripts/flash_system.sh -r $(DEVICE_IP)
 
+ifeq ($(strip $(RELEASE_REF)),)
 test:
 	$(MAKE) check_device
 	$(MAKE) check_remote
@@ -68,12 +82,17 @@ else
 	$(MAKE) flash SKIP_BUILD=1
 endif
 	./scripts/run_e2e_tests.sh -r $(DEVICE_IP) --remote-host $(JETKVM_REMOTE_HOST) $(if $(KVM_DIR),--kvm-dir $(KVM_DIR))
+else
+test:
+	@$(TEST_FROM_REF_ENVS) ./scripts/test_from_ref.sh --ref "$(RELEASE_REF)"
+endif
 
 # -----------------------------------------------------------------------------
 # Dev Release - Prerelease for testing
 # -----------------------------------------------------------------------------
-dev_release: export BUILD_VERSION := $(VERSION_DEV)
-dev_release: git_check_dev test
+ifeq ($(strip $(RELEASE_REF)),)
+dev_release: git_check_dev
+	@$(MAKE) BUILD_VERSION="$(VERSION_DEV)" test
 	@if rclone lsf $(R2_PATH)/$(VERSION_DEV)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION_DEV) already exists in R2"; exit 1; \
 	fi
@@ -91,23 +110,28 @@ dev_release: git_check_dev test
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	./scripts/release_r2.sh --version $(VERSION_DEV)
-	./scripts/release_github.sh --version $(VERSION_DEV) --prerelease
+	RELEASE_SOURCE_REF="$$(git rev-parse --abbrev-ref HEAD)" RELEASE_SOURCE_COMMIT="$$(git rev-parse HEAD)" ./scripts/release_r2.sh --version $(VERSION_DEV)
+	RELEASE_SOURCE_REF="$$(git rev-parse --abbrev-ref HEAD)" RELEASE_SOURCE_COMMIT="$$(git rev-parse HEAD)" ./scripts/release_github.sh --version $(VERSION_DEV) --prerelease
 	@echo ""
 	@echo "OK: Dev release complete: release/v$(VERSION_DEV)"
+else
+dev_release:
+	@$(RELEASE_FROM_REF_ENVS) ./scripts/release_from_ref.sh --kind dev --ref "$(RELEASE_REF)"
+endif
 
 # -----------------------------------------------------------------------------
 # Production Release
 # -----------------------------------------------------------------------------
-release: export BUILD_VERSION := $(VERSION)
-release: git_check_dev test
+ifeq ($(strip $(RELEASE_REF)),)
+release: git_check_dev
+	@$(MAKE) BUILD_VERSION="$(VERSION)" test
 	@if rclone lsf $(R2_PATH)/$(VERSION)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION) already exists in R2"; exit 1; \
 	fi
 	@if gh release view "release/v$(VERSION)" --repo jetkvm/rv1106-system >/dev/null 2>&1; then \
 		echo "Error: GitHub release release/v$(VERSION) already exists"; exit 1; \
 	fi
-	@latest_dev=$$(gh release list --repo jetkvm/rv1106-system --limit 10 --json tagName --jq '.[].tagName' | grep "^release/v$(VERSION)-dev" | head -1); \
+	@latest_dev=$$(gh release list --repo jetkvm/rv1106-system --limit 10 --json tagName --jq -r '.[].tagName' | grep "^release/v$(VERSION)-dev" | head -1); \
 		if [ -z "$$latest_dev" ]; then \
 			echo ""; \
 			echo "WARNING: No dev release found for $(VERSION)"; \
@@ -128,12 +152,16 @@ release: git_check_dev test
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed with PRODUCTION release? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	./scripts/release_r2.sh --version $(VERSION)
-	./scripts/release_github.sh --version $(VERSION)
+	RELEASE_SOURCE_REF="$$(git rev-parse --abbrev-ref HEAD)" RELEASE_SOURCE_COMMIT="$$(git rev-parse HEAD)" ./scripts/release_r2.sh --version $(VERSION)
+	RELEASE_SOURCE_REF="$$(git rev-parse --abbrev-ref HEAD)" RELEASE_SOURCE_COMMIT="$$(git rev-parse HEAD)" ./scripts/release_github.sh --version $(VERSION)
 	@echo ""
 	@echo "OK: Production release complete: release/v$(VERSION)"
 	@echo ""
 	@echo "Next: Run 'make bump-version' to prepare for next release cycle"
+else
+release:
+	@$(RELEASE_FROM_REF_ENVS) ./scripts/release_from_ref.sh --kind prod --ref "$(RELEASE_REF)"
+endif
 
 # -----------------------------------------------------------------------------
 # Bump Version
@@ -159,6 +187,7 @@ bump-version:
 clean:
 	@echo "Cleaning build artifacts..."
 	sudo rm -rf output/
+	./build.sh lunch "$(BUILD_BOARD_CONFIG)"
 	./build.sh clean
 	rm -f buildkit.tar.zst
 	@echo "OK: Clean complete"

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 SCRIPT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")
 ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+BUILD_BOARD_CONFIG="${BUILD_BOARD_CONFIG:-BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk}"
 
 source "${SCRIPT_DIR}/common.sh"
 
@@ -15,12 +16,14 @@ fi
 
 msg_info ">> Building rv1106-system..."
 cd "$ROOT_DIR"
+msg_info "  Build version: ${BUILD_VERSION}"
+print_release_source
 
 msg_info "  Updating JetKVM app binary..."
 ./update_app.sh
 
-msg_info "  Running build.sh lunch..."
-./build.sh lunch BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
+msg_info "  Running build.sh lunch for ${BUILD_BOARD_CONFIG}..."
+./build.sh lunch "${BUILD_BOARD_CONFIG}"
 
 msg_info "  Running build.sh..."
 ./build.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -31,6 +31,24 @@ msg_ok() { msg "$1" "$C_OK"; }
 msg_err() { msg "$1" "$C_ERR"; }
 msg_warn() { msg "$1" "$C_WARN"; }
 
+short_commit() {
+    local commit="${1:-}"
+    if [ -z "$commit" ]; then
+        printf '%s' ""
+        return 0
+    fi
+    printf '%s' "${commit:0:12}"
+}
+
+print_release_source() {
+    if [ -n "${RELEASE_SOURCE_REF:-}" ]; then
+        msg_info "  Source ref:    ${RELEASE_SOURCE_REF}"
+    fi
+    if [ -n "${RELEASE_SOURCE_COMMIT:-}" ]; then
+        msg_info "  Source commit: $(short_commit "${RELEASE_SOURCE_COMMIT}")"
+    fi
+}
+
 # -----------------------------------------------------------------------------
 # SSH helper
 # -----------------------------------------------------------------------------
@@ -111,9 +129,9 @@ wait_for_device() {
         exit 1
     fi
 
-    # Wait for web interface (up to 60 seconds)
+    # Wait for web interface (up to 180 seconds)
     msg_info "  Waiting for web interface..."
-    max_attempts=30
+    max_attempts=90
     attempt=1
     while [ $attempt -le $max_attempts ]; do
         if curl -s --max-time 5 "http://${DEVICE_IP}" > /dev/null 2>&1; then

--- a/scripts/release_from_ref.sh
+++ b/scripts/release_from_ref.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+
+RELEASE_KIND=""
+RELEASE_REF=""
+WORKTREE_PARENT=""
+WORKTREE_DIR=""
+
+source "${SCRIPT_DIR}/common.sh"
+
+BUILD_BOARD_CONFIG="${BUILD_BOARD_CONFIG:-BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk}"
+
+show_help() {
+    echo "Usage: $0 --kind <dev|prod> --ref <commit|tag|branch>"
+    echo
+    echo "Options:"
+    echo "  --kind <kind>     Release kind: dev or prod"
+    echo "  --ref <git-ref>   Source git ref to build, test, and publish"
+    echo "  --help            Show this help message"
+    echo
+}
+
+cleanup() {
+    local exit_code=$?
+
+    if [ -n "$WORKTREE_DIR" ] && [ -d "$WORKTREE_DIR" ]; then
+        msg_info ">> Cleaning up temporary worktree..."
+        git -C "$ROOT_DIR" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || rm -rf "$WORKTREE_DIR"
+    fi
+
+    if [ -n "$WORKTREE_PARENT" ] && [ -d "$WORKTREE_PARENT" ]; then
+        rm -rf "$WORKTREE_PARENT"
+    fi
+
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --kind)
+            if [ -z "${2:-}" ] || [[ "$2" == -* ]]; then
+                msg_err "Error: --kind requires a value (dev or prod)"
+                exit 1
+            fi
+            RELEASE_KIND="$2"
+            shift 2
+            ;;
+        --ref)
+            if [ -z "${2:-}" ] || [[ "$2" == -* ]]; then
+                msg_err "Error: --ref requires a value"
+                exit 1
+            fi
+            RELEASE_REF="$2"
+            shift 2
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            msg_err "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$RELEASE_KIND" ] || [ -z "$RELEASE_REF" ]; then
+    msg_err "Error: --kind and --ref are required"
+    show_help
+    exit 1
+fi
+
+if [ "$RELEASE_KIND" != "dev" ] && [ "$RELEASE_KIND" != "prod" ]; then
+    msg_err "Error: --kind must be 'dev' or 'prod'"
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if [ -n "$(git status --porcelain)" ]; then
+    if [ "${ALLOW_DIRTY:-}" = "1" ]; then
+        msg_warn "WARNING: Working tree is dirty, continuing because ALLOW_DIRTY=1"
+    else
+        msg_err "Error: Working tree is dirty. Commit or stash changes, or rerun with ALLOW_DIRTY=1."
+        exit 1
+    fi
+fi
+
+command -v gh >/dev/null 2>&1 || { msg_err "Error: gh CLI not installed"; exit 1; }
+gh auth status >/dev/null 2>&1 || { msg_err "Error: gh CLI not authenticated. Run 'gh auth login'"; exit 1; }
+command -v rclone >/dev/null 2>&1 || { msg_err "Error: rclone not installed"; exit 1; }
+
+resolved_commit=$(git rev-parse --verify "${RELEASE_REF}^{commit}")
+WORKTREE_PARENT=$(mktemp -d)
+WORKTREE_DIR="${WORKTREE_PARENT}/repo"
+
+msg_info ">> Preparing temporary worktree from ${RELEASE_REF}..."
+git worktree add --detach "$WORKTREE_DIR" "$resolved_commit" >/dev/null
+
+base_version=$(cat "${WORKTREE_DIR}/VERSION" 2>/dev/null || echo "0.0.0")
+if [ "$RELEASE_KIND" = "dev" ]; then
+    build_version="${base_version}-dev$(date -u +%Y%m%d%H%M)"
+    release_label="DEV Release (Pre-release)"
+    release_done="OK: Dev release complete: release/v${build_version}"
+else
+    build_version="${base_version}"
+    release_label="PRODUCTION Release"
+    release_done="OK: Production release complete: release/v${build_version}"
+fi
+
+export RELEASE_SOURCE_REF="$RELEASE_REF"
+export RELEASE_SOURCE_COMMIT="$resolved_commit"
+
+if [ "$RELEASE_KIND" = "prod" ]; then
+    release_tags=$(gh release list --repo jetkvm/rv1106-system --limit 10 --json tagName --jq -r '.[].tagName')
+    latest_dev=$(printf '%s\n' "$release_tags" | grep -m 1 "^release/v${build_version}-dev" || true)
+
+    if [ -z "$latest_dev" ]; then
+        echo ""
+        msg_warn "WARNING: No dev release found for ${build_version}"
+        echo ""
+        read -p "Release production from ${RELEASE_REF} without prior dev release? [y/N] " confirm
+        if [ "$confirm" != "y" ]; then
+            exit 1
+        fi
+    else
+        msg_ok "OK: Found prior dev release: ${latest_dev}"
+    fi
+fi
+
+echo ""
+msg_info "═══════════════════════════════════════════════════════"
+msg_info "  ${release_label}"
+msg_info "═══════════════════════════════════════════════════════"
+msg_info "  Version: ${build_version}"
+msg_info "  Tag:     release/v${build_version}"
+print_release_source
+msg_info "  Worktree: ${WORKTREE_DIR}"
+msg_info "  Time:    $(date -u +%FT%T%z)"
+msg_info "═══════════════════════════════════════════════════════"
+echo ""
+
+if [ "$RELEASE_KIND" = "dev" ]; then
+    read -p "Proceed with DEV release from ${RELEASE_REF}? [y/N] " confirm
+else
+    read -p "Proceed with PRODUCTION release from ${RELEASE_REF}? [y/N] " confirm
+fi
+if [ "$confirm" != "y" ]; then
+    exit 1
+fi
+
+make_args=( "BUILD_VERSION=${build_version}" )
+
+for var_name in DEVICE_IP DEVICE_USER JETKVM_REMOTE_HOST KVM_DIR KVM_BRANCH KVM_REPO SKIP_BUILD R2_PATH; do
+    if [ -n "${!var_name:-}" ]; then
+        make_args+=( "${var_name}=${!var_name}" )
+    fi
+done
+
+msg_info ">> Running build, flash, and test in temporary worktree..."
+(
+    cd "$WORKTREE_DIR"
+    export RELEASE_SOURCE_REF RELEASE_SOURCE_COMMIT BUILD_VERSION="$build_version"
+    msg_info "  Selecting board config ${BUILD_BOARD_CONFIG} in temporary worktree..."
+    ./build.sh lunch "${BUILD_BOARD_CONFIG}"
+    make RELEASE_REF= "${make_args[@]}" test
+
+    echo ""
+    msg_info "═══════════════════════════════════════════════════════"
+    msg_info "  Final Check: R2 Upload"
+    msg_info "═══════════════════════════════════════════════════════"
+    msg_info "  Version: ${build_version}"
+    msg_info "  Destination: ${R2_PATH}/${build_version}/"
+    print_release_source
+    msg_info "═══════════════════════════════════════════════════════"
+    echo ""
+    read -p "Proceed to R2 upload for ${build_version}? [y/N] " confirm
+    if [ "$confirm" != "y" ]; then
+        msg_warn "R2 upload cancelled before publish."
+        exit 1
+    fi
+
+    ./scripts/release_r2.sh --version "$build_version"
+
+    github_args=( "--version" "$build_version" "--target-commit" "$resolved_commit" "--source-ref" "$RELEASE_REF" )
+    if [ "$RELEASE_KIND" = "dev" ]; then
+        github_args+=( "--prerelease" )
+    fi
+
+    echo ""
+    msg_info "═══════════════════════════════════════════════════════"
+    msg_info "  Final Check: GitHub Release"
+    msg_info "═══════════════════════════════════════════════════════"
+    msg_info "  Version: ${build_version}"
+    msg_info "  Tag:     release/v${build_version}"
+    if [ "$RELEASE_KIND" = "dev" ]; then
+        msg_info "  Type:    prerelease"
+    else
+        msg_info "  Type:    production release"
+    fi
+    print_release_source
+    msg_info "═══════════════════════════════════════════════════════"
+    echo ""
+    read -p "Proceed to GitHub tag/release for ${build_version}? [y/N] " confirm
+    if [ "$confirm" != "y" ]; then
+        msg_warn "GitHub release cancelled before publish."
+        exit 1
+    fi
+
+    ./scripts/release_github.sh "${github_args[@]}"
+)
+
+echo ""
+msg_ok "${release_done}"

--- a/scripts/release_github.sh
+++ b/scripts/release_github.sh
@@ -7,16 +7,20 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 BUILD_VERSION=""
 PRERELEASE=false
+TARGET_COMMIT=""
+SOURCE_REF=""
 
 source "${SCRIPT_DIR}/common.sh"
 
 show_help() {
-    echo "Usage: $0 --version <version> [--prerelease]"
+    echo "Usage: $0 --version <version> [--prerelease] [--target-commit <sha>] [--source-ref <ref>]"
     echo
     echo "Options:"
-    echo "  --version <version>   Release version (e.g., 0.2.7)"
-    echo "  --prerelease          Mark release as prerelease"
-    echo "  --help                Show this help message"
+    echo "  --version <version>       Release version (e.g., 0.2.7)"
+    echo "  --prerelease              Mark release as prerelease"
+    echo "  --target-commit <sha>     Commit to tag/release (defaults to HEAD)"
+    echo "  --source-ref <ref>        Source ref label shown in confirmation output"
+    echo "  --help                    Show this help message"
     echo
 }
 
@@ -29,6 +33,14 @@ while [[ $# -gt 0 ]]; do
         --prerelease)
             PRERELEASE=true
             shift
+            ;;
+        --target-commit)
+            TARGET_COMMIT="$2"
+            shift 2
+            ;;
+        --source-ref)
+            SOURCE_REF="$2"
+            shift 2
             ;;
         --help)
             show_help
@@ -51,6 +63,16 @@ command -v gh >/dev/null 2>&1 || { msg_err "Error: gh CLI not installed"; exit 1
 gh auth status >/dev/null 2>&1 || { msg_err "Error: gh CLI not authenticated. Run 'gh auth login'"; exit 1; }
 
 cd "$ROOT_DIR"
+
+if [ -n "$SOURCE_REF" ]; then
+    export RELEASE_SOURCE_REF="$SOURCE_REF"
+fi
+
+if [ -z "$TARGET_COMMIT" ]; then
+    TARGET_COMMIT=$(git rev-parse HEAD)
+fi
+TARGET_COMMIT=$(git rev-parse --verify "${TARGET_COMMIT}^{commit}")
+export RELEASE_SOURCE_COMMIT="$TARGET_COMMIT"
 
 ota_tar="$OTA_TAR"
 full_img="$FULL_IMG"
@@ -90,7 +112,7 @@ msg_info "═══════════════════════�
 msg_info "  Version: ${BUILD_VERSION}"
 msg_info "  Tag:     release/v${BUILD_VERSION}"
 msg_info "  Branch:  $(git rev-parse --abbrev-ref HEAD)"
-msg_info "  Commit:  $(git rev-parse --short HEAD)"
+print_release_source
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Files to upload:"
 msg_info "    - update_ota.tar    (${ota_size})"
@@ -105,7 +127,7 @@ if [ "$confirm" != "y" ]; then
 fi
 
 msg_info ">> Creating git tag release/v${BUILD_VERSION}..."
-git tag "release/v${BUILD_VERSION}"
+git tag "release/v${BUILD_VERSION}" "${TARGET_COMMIT}"
 git push origin "release/v${BUILD_VERSION}"
 
 msg_info ">> Creating GitHub release..."

--- a/scripts/release_r2.sh
+++ b/scripts/release_r2.sh
@@ -78,6 +78,7 @@ msg_info "═══════════════════════�
 msg_info "  R2 Upload"
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Destination: ${R2_PATH}/${BUILD_VERSION}/"
+print_release_source
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Files to upload:"
 msg_info "    - update_ota.tar     → system.tar"

--- a/scripts/test_from_ref.sh
+++ b/scripts/test_from_ref.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+SCRIPT_DIR=$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+
+TEST_REF=""
+WORKTREE_PARENT=""
+WORKTREE_DIR=""
+
+source "${SCRIPT_DIR}/common.sh"
+
+BUILD_BOARD_CONFIG="${BUILD_BOARD_CONFIG:-BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk}"
+
+show_help() {
+    echo "Usage: $0 --ref <commit|tag|branch>"
+    echo
+    echo "Options:"
+    echo "  --ref <git-ref>   Source git ref to build, flash, and test"
+    echo "  --help            Show this help message"
+    echo
+}
+
+cleanup() {
+    local exit_code=$?
+
+    if [ -n "$WORKTREE_DIR" ] && [ -d "$WORKTREE_DIR" ]; then
+        msg_info ">> Cleaning up temporary worktree..."
+        git -C "$ROOT_DIR" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || rm -rf "$WORKTREE_DIR"
+    fi
+
+    if [ -n "$WORKTREE_PARENT" ] && [ -d "$WORKTREE_PARENT" ]; then
+        rm -rf "$WORKTREE_PARENT"
+    fi
+
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ref)
+            if [ -z "${2:-}" ] || [[ "$2" == -* ]]; then
+                msg_err "Error: --ref requires a value"
+                exit 1
+            fi
+            TEST_REF="$2"
+            shift 2
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            msg_err "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$TEST_REF" ]; then
+    msg_err "Error: --ref is required"
+    show_help
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+
+if [ -n "$(git status --porcelain)" ]; then
+    if [ "${ALLOW_DIRTY:-}" = "1" ]; then
+        msg_warn "WARNING: Working tree is dirty, continuing because ALLOW_DIRTY=1"
+    else
+        msg_err "Error: Working tree is dirty. Commit or stash changes, or rerun with ALLOW_DIRTY=1."
+        exit 1
+    fi
+fi
+
+resolved_commit=$(git rev-parse --verify "${TEST_REF}^{commit}")
+WORKTREE_PARENT=$(mktemp -d)
+WORKTREE_DIR="${WORKTREE_PARENT}/repo"
+
+msg_info ">> Preparing temporary worktree from ${TEST_REF}..."
+git worktree add --detach "$WORKTREE_DIR" "$resolved_commit" >/dev/null
+
+export RELEASE_SOURCE_REF="$TEST_REF"
+export RELEASE_SOURCE_COMMIT="$resolved_commit"
+
+echo ""
+msg_info "═══════════════════════════════════════════════════════"
+msg_info "  TEST From Ref"
+msg_info "═══════════════════════════════════════════════════════"
+print_release_source
+msg_info "  Worktree: ${WORKTREE_DIR}"
+if [ -n "${BUILD_VERSION:-}" ]; then
+    msg_info "  Build version override: ${BUILD_VERSION}"
+fi
+msg_info "  Time:    $(date -u +%FT%T%z)"
+msg_info "═══════════════════════════════════════════════════════"
+echo ""
+
+make_args=()
+
+for var_name in DEVICE_IP DEVICE_USER JETKVM_REMOTE_HOST KVM_DIR KVM_BRANCH KVM_REPO SKIP_BUILD BUILD_VERSION; do
+    if [ -n "${!var_name:-}" ]; then
+        make_args+=( "${var_name}=${!var_name}" )
+    fi
+done
+
+msg_info ">> Running build, flash, and test in temporary worktree..."
+(
+    cd "$WORKTREE_DIR"
+    export RELEASE_SOURCE_REF RELEASE_SOURCE_COMMIT
+    if [ -n "${BUILD_VERSION:-}" ]; then
+        export BUILD_VERSION
+    fi
+    msg_info "  Selecting board config ${BUILD_BOARD_CONFIG} in temporary worktree..."
+    ./build.sh lunch "${BUILD_BOARD_CONFIG}"
+    make RELEASE_REF= "${make_args[@]}" test
+)
+
+echo ""
+msg_ok "OK: Test completed for ${TEST_REF}"


### PR DESCRIPTION
## Summary
- add ref-based `test`, `dev_release`, and `release` workflows using temporary worktrees so known-good commits can be exercised without rewriting `dev`
- pin publish steps to the selected source commit and add extra confirmation prompts plus source/version logging before R2 and GitHub actions
- improve test ergonomics with board auto-selection, `ALLOW_DIRTY`, and a longer post-OTA web readiness wait

## Test plan
- [x] `bash -n scripts/common.sh scripts/build_system.sh scripts/release_r2.sh scripts/release_github.sh scripts/release_from_ref.sh scripts/test_from_ref.sh`
- [x] `make -n dev_release`
- [x] `make -n release`
- [x] `make -n dev_release RELEASE_REF=b273513f0`
- [x] `make -n release RELEASE_REF=b273513f0`
- [x] `make -n test RELEASE_REF=b273513f0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/test automation that publishes artifacts and creates tags/releases; mistakes could publish from or tag the wrong commit despite added confirmations and explicit commit pinning.
> 
> **Overview**
> Adds optional **ref-based** `make test`, `dev_release`, and `release` flows via `RELEASE_REF=<git-ref>`, which run build/flash/E2E in a temporary git worktree so known-good commits/tags can be exercised and published without switching the local branch.
> 
> Release scripts now record and display the *source ref/commit* across build, R2 upload, and GitHub release confirmations; GitHub tagging is pinned to an explicit `--target-commit` (not implicitly `HEAD`). Build ergonomics are improved by making the board config selectable via `BUILD_BOARD_CONFIG` (used by `clean` and `build_system.sh`) and by extending the post-flash web readiness wait from 60s to 180s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67dd6c60c76b8e25462ac56fe4c543c7aa614ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->