### PR TITLE
feat(release): sign production OTA uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2204
     name: Build
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     name: Build
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ OTA_ROOT_KEY_FPR := AF5A36A993D828FEFE7C18C2D1B9856C26A79E95
 
 .PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote check_signing_key
 
+# Keep production signing validation ahead of build/test even under `make -j`.
+.NOTPARALLEL: release
+
 # -----------------------------------------------------------------------------
 # Git checks
 # -----------------------------------------------------------------------------
@@ -128,8 +131,7 @@ dev_release: git_check_dev test
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-# Next line: SIGNING_KEY_FPR= clears the var for this subprocess only (no production signature on dev uploads).
-	SIGNING_KEY_FPR= ./scripts/release_r2.sh --version $(VERSION_DEV)
+	./scripts/release_r2.sh --version $(VERSION_DEV) --unsigned
 	./scripts/release_github.sh --version $(VERSION_DEV) --prerelease
 	@echo ""
 	@echo "OK: Dev release complete: release/v$(VERSION_DEV)"
@@ -168,7 +170,7 @@ release: check_signing_key git_check_dev test
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed with PRODUCTION release? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	SIGNING_KEY_FPR=$(SIGNING_KEY_FPR) ./scripts/release_r2.sh --version $(VERSION)
+	./scripts/release_r2.sh --version $(VERSION) --signing-key $(SIGNING_KEY_FPR)
 	./scripts/release_github.sh --version $(VERSION)
 	@echo ""
 	@echo "OK: Production release complete: release/v$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,7 @@ dev_release: git_check_dev test
 # Production Release
 # -----------------------------------------------------------------------------
 release: export BUILD_VERSION := $(VERSION)
-release: git_check_dev test
-	$(MAKE) check_signing_key SIGNING_KEY_FPR=$(SIGNING_KEY_FPR)
+release: check_signing_key git_check_dev test
 	@if rclone lsf $(R2_PATH)/$(VERSION)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION) already exists in R2"; exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ VERSION_DEV := $(VERSION)-dev$(shell date -u +%Y%m%d%H%M)
 
 DEVICE_IP ?= 192.168.1.77
 R2_PATH := r2://jetkvm-update/system
+SIGNING_KEY_FPR ?=
+OTA_ROOT_KEY_FPR := AF5A36A993D828FEFE7C18C2D1B9856C26A79E95
 
-.PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote
+.PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote check_signing_key
 
 # -----------------------------------------------------------------------------
 # Git checks
@@ -47,6 +49,26 @@ git_check_dev:
 	echo ""; \
 	read -p "Continue with this checkout? [y/N] " confirm; \
 	[ "$$confirm" = "y" ] || exit 1
+
+check_signing_key:
+	@if [ -z "$(SIGNING_KEY_FPR)" ]; then \
+		echo "Error: SIGNING_KEY_FPR is required for production releases"; \
+		echo "Usage: make release SIGNING_KEY_FPR=<fingerprint> [DEVICE_IP=<ip>] [JETKVM_REMOTE_HOST=<host>]"; \
+		exit 1; \
+	fi
+	@gpg --list-secret-keys --with-colons $(SIGNING_KEY_FPR) >/dev/null 2>&1 || { \
+		echo "Error: Signing key $(SIGNING_KEY_FPR) not found in local GPG keyring"; \
+		exit 1; \
+	}
+	@root_fpr="$$(gpg --list-secret-keys --with-colons $(SIGNING_KEY_FPR) | awk -F: '/^fpr:/ { print $$10; exit }')"; \
+	if [ -z "$$root_fpr" ]; then \
+		echo "Error: Could not determine root fingerprint for signing key $(SIGNING_KEY_FPR)"; \
+		exit 1; \
+	fi; \
+	if [ "$$root_fpr" != "$(OTA_ROOT_KEY_FPR)" ]; then \
+		echo "Error: Signing key $(SIGNING_KEY_FPR) belongs to root $$root_fpr, expected $(OTA_ROOT_KEY_FPR)"; \
+		exit 1; \
+	fi
 
 # -----------------------------------------------------------------------------
 # Build / Flash / Test (dependency chain)
@@ -106,7 +128,8 @@ dev_release: git_check_dev test
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	./scripts/release_r2.sh --version $(VERSION_DEV)
+# Next line: SIGNING_KEY_FPR= clears the var for this subprocess only (no production signature on dev uploads).
+	SIGNING_KEY_FPR= ./scripts/release_r2.sh --version $(VERSION_DEV)
 	./scripts/release_github.sh --version $(VERSION_DEV) --prerelease
 	@echo ""
 	@echo "OK: Dev release complete: release/v$(VERSION_DEV)"
@@ -116,6 +139,7 @@ dev_release: git_check_dev test
 # -----------------------------------------------------------------------------
 release: export BUILD_VERSION := $(VERSION)
 release: git_check_dev test
+	$(MAKE) check_signing_key SIGNING_KEY_FPR=$(SIGNING_KEY_FPR)
 	@if rclone lsf $(R2_PATH)/$(VERSION)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION) already exists in R2"; exit 1; \
 	fi
@@ -141,10 +165,11 @@ release: git_check_dev test
 	@echo "  Commit:  $$(git rev-parse --short HEAD)"
 	@echo "  Subject: $$(git log -1 --pretty=%s)"
 	@echo "  Time:    $$(date -u +%FT%T%z)"
+	@echo "  Signing: $(SIGNING_KEY_FPR)"
 	@echo "═══════════════════════════════════════════════════════"
 	@echo ""
 	@read -p "Proceed with PRODUCTION release? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	./scripts/release_r2.sh --version $(VERSION)
+	SIGNING_KEY_FPR=$(SIGNING_KEY_FPR) ./scripts/release_r2.sh --version $(VERSION)
 	./scripts/release_github.sh --version $(VERSION)
 	@echo ""
 	@echo "OK: Production release complete: release/v$(VERSION)"

--- a/scripts/release_r2.sh
+++ b/scripts/release_r2.sh
@@ -7,6 +7,7 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 BUILD_VERSION=""
 R2_PATH="${R2_PATH:-r2://jetkvm-update/system}"
+SIGNING_KEY_FPR="${SIGNING_KEY_FPR:-}"
 
 source "${SCRIPT_DIR}/common.sh"
 
@@ -48,6 +49,7 @@ cd "$ROOT_DIR"
 
 ota_tar="$OTA_TAR"
 ota_sha="${OTA_TAR}.sha256"
+ota_sig="${OTA_TAR}.sig"
 full_img="$FULL_IMG"
 img_sha="${FULL_IMG}.sha256"
 
@@ -70,6 +72,33 @@ if rclone lsf "${R2_PATH}/${BUILD_VERSION}/" 2>/dev/null | grep -q .; then
     exit 1
 fi
 
+if [ -n "$SIGNING_KEY_FPR" ]; then
+    msg_info ">> Signing OTA payload with ${SIGNING_KEY_FPR}..."
+    read -p "Ensure the YubiKey is inserted and ready, then continue signing? [y/N] " confirm_sign
+    if [ "$confirm_sign" != "y" ]; then
+        msg_warn "Signing cancelled."
+        exit 1
+    fi
+    rm -f "$ota_sig"
+
+    for attempt in 1 2 3; do
+        if gpg --yes --detach-sign --output "$ota_sig" --local-user "$SIGNING_KEY_FPR" "$ota_tar"; then
+            break
+        fi
+        rm -f "$ota_sig"
+        if [ "$attempt" -eq 3 ]; then
+            msg_err "Error: GPG signing failed after 3 attempts"
+            exit 1
+        fi
+        msg_warn "GPG signing failed (attempt ${attempt}/3). Please retry."
+    done
+
+    if [ ! -f "$ota_sig" ]; then
+        msg_err "Error: Signature file not created: $ota_sig"
+        exit 1
+    fi
+fi
+
 ota_hash=$(cat "$ota_sha")
 img_hash=$(cat "$img_sha")
 
@@ -82,6 +111,9 @@ msg_info "═══════════════════════�
 msg_info "  Files to upload:"
 msg_info "    - update_ota.tar     → system.tar"
 msg_info "      SHA256: ${ota_hash}"
+if [ -n "$SIGNING_KEY_FPR" ]; then
+    msg_info "      Signature: ${ota_sig} → system.tar.sig"
+fi
 msg_info "    - update.img         → update.img"
 msg_info "      SHA256: ${img_hash}"
 msg_info "═══════════════════════════════════════════════════════"
@@ -95,6 +127,9 @@ fi
 msg_info ">> Uploading to R2..."
 rclone copyto --progress "$ota_tar" "${R2_PATH}/${BUILD_VERSION}/system.tar"
 rclone copyto --progress "$ota_sha" "${R2_PATH}/${BUILD_VERSION}/system.tar.sha256"
+if [ -n "$SIGNING_KEY_FPR" ]; then
+    rclone copyto --progress "$ota_sig" "${R2_PATH}/${BUILD_VERSION}/system.tar.sig"
+fi
 rclone copyto --progress "$full_img" "${R2_PATH}/${BUILD_VERSION}/update.img"
 rclone copyto --progress "$img_sha" "${R2_PATH}/${BUILD_VERSION}/update.img.sha256"
 

--- a/scripts/release_r2.sh
+++ b/scripts/release_r2.sh
@@ -7,24 +7,75 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 BUILD_VERSION=""
 R2_PATH="${R2_PATH:-r2://jetkvm-update/system}"
-SIGNING_KEY_FPR="${SIGNING_KEY_FPR:-}"
+SIGNING_KEY_FPR=""
+UNSIGNED=false
+OTA_ROOT_KEY_FPR="AF5A36A993D828FEFE7C18C2D1B9856C26A79E95"
 
 source "${SCRIPT_DIR}/common.sh"
 
 show_help() {
-    echo "Usage: $0 --version <version>"
+    echo "Usage: $0 --version <version> (--signing-key <fingerprint> | --unsigned)"
     echo
     echo "Options:"
     echo "  --version <version>   Release version (e.g., 0.2.7)"
+    echo "  --signing-key <fpr>   Sign the OTA payload with the trusted production key"
+    echo "  --unsigned            Upload without an OTA signature (dev/prerelease only)"
     echo "  --help                Show this help message"
     echo
+}
+
+validate_signing_key() {
+    local signing_key_fpr="$1"
+    local root_fpr
+
+    if [ -z "$signing_key_fpr" ]; then
+        msg_err "Error: signing key fingerprint is required"
+        exit 1
+    fi
+
+    command -v gpg >/dev/null 2>&1 || { msg_err "Error: gpg not installed"; exit 1; }
+    gpg --list-secret-keys --with-colons "$signing_key_fpr" >/dev/null 2>&1 || {
+        msg_err "Error: Signing key ${signing_key_fpr} not found in local GPG keyring"
+        exit 1
+    }
+
+    root_fpr=$(gpg --list-secret-keys --with-colons "$signing_key_fpr" | awk -F: '/^fpr:/ { print $10; exit }')
+    if [ -z "$root_fpr" ]; then
+        msg_err "Error: Could not determine root fingerprint for signing key ${signing_key_fpr}"
+        exit 1
+    fi
+
+    if [ "$root_fpr" != "$OTA_ROOT_KEY_FPR" ]; then
+        msg_err "Error: Signing key ${signing_key_fpr} belongs to root ${root_fpr}, expected ${OTA_ROOT_KEY_FPR}"
+        exit 1
+    fi
+}
+
+require_arg() {
+    local option="$1"
+    local value="${2:-}"
+
+    if [ -z "$value" ]; then
+        msg_err "Error: ${option} requires a value"
+        exit 1
+    fi
 }
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --version)
+            require_arg "$1" "${2:-}"
             BUILD_VERSION="$2"
             shift 2
+            ;;
+        --signing-key)
+            require_arg "$1" "${2:-}"
+            SIGNING_KEY_FPR="$2"
+            shift 2
+            ;;
+        --unsigned)
+            UNSIGNED=true
+            shift
             ;;
         --help)
             show_help
@@ -41,6 +92,20 @@ done
 if [ -z "$BUILD_VERSION" ]; then
     msg_err "Error: --version is required"
     exit 1
+fi
+
+if [ -n "$SIGNING_KEY_FPR" ] && [ "$UNSIGNED" = true ]; then
+    msg_err "Error: choose either --signing-key or --unsigned, not both"
+    exit 1
+fi
+
+if [ -z "$SIGNING_KEY_FPR" ] && [ "$UNSIGNED" != true ]; then
+    msg_err "Error: choose --signing-key <fingerprint> for production or --unsigned for dev/prerelease uploads"
+    exit 1
+fi
+
+if [ -n "$SIGNING_KEY_FPR" ]; then
+    validate_signing_key "$SIGNING_KEY_FPR"
 fi
 
 command -v rclone >/dev/null 2>&1 || { msg_err "Error: rclone not installed"; exit 1; }


### PR DESCRIPTION
## Summary
- require a production signing key before running `make release`
- sign `update_ota.tar` during production R2 uploads and publish `system.tar.sig`
- keep dev releases unsigned by explicitly clearing the signing key for prerelease uploads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release pipeline to require and validate a specific GPG signing key and to upload a new signature artifact to R2; mistakes could block releases or publish incorrectly signed/unsigned OTA payloads.
> 
> **Overview**
> Production releases now **require an explicit GPG signing key**: `make release` adds a `check_signing_key` gate that verifies the provided `SIGNING_KEY_FPR` exists locally and matches the expected root fingerprint, and prints the selected signing fingerprint in the release confirmation.
> 
> `scripts/release_r2.sh` now supports `--signing-key <fpr>` vs `--unsigned` (mutually exclusive). When signing is enabled, it **detach-signs** `update_ota.tar` (with retry + operator confirmation) and uploads the resulting `system.tar.sig` alongside the existing `system.tar` and checksums; dev/prerelease uploads are explicitly forced to be unsigned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b8689409d3672bba00ccaa59f2fdf9dfd571a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->