### PR TITLE
Add SKU-aware system release flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 IMAGE/*
 output/*
+release-artifacts/*
 !IMAGE/.gitkeep
 !output/.gitkeep
 .BoardConfig.mk

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@
 #   build        - Build rv1106-system image
 #   flash        - Flash system image to device (depends on build)
 #   test         - Run E2E tests (depends on flash)
-#   dev_release  - Dev release (prerelease) with testing
-#   release      - Production release with testing
+#   dev_release  - Dev release (prerelease) with optional per-SKU testing
+#   release      - Production release with optional per-SKU testing
+#   release_dry_run - Build, optionally test, and sign without uploading
 #   bump-version - Bump version for next release cycle
 
 VERSION := $(shell cat VERSION 2>/dev/null || echo "0.0.0")
@@ -16,10 +17,10 @@ R2_PATH := r2://jetkvm-update/system
 SIGNING_KEY_FPR ?=
 OTA_ROOT_KEY_FPR := AF5A36A993D828FEFE7C18C2D1B9856C26A79E95
 
-.PHONY: build flash test dev_release release bump-version git_check_dev clean check_device check_remote check_signing_key
+.PHONY: build flash test dev_release release release_dry_run bump-version git_check_dev clean check_device check_remote check_signing_key
 
-# Keep production signing validation ahead of build/test even under `make -j`.
-.NOTPARALLEL: release
+# Keep release validation, build/test prompts, and signing ordered even under `make -j`.
+.NOTPARALLEL: dev_release release release_dry_run
 
 # -----------------------------------------------------------------------------
 # Git checks
@@ -94,7 +95,7 @@ check_remote:
 flash:
 	$(MAKE) check_device
 ifndef SKIP_BUILD
-	$(MAKE) build
+	PROMPT_VARIANT_TESTS=0 $(MAKE) build
 endif
 	./scripts/flash_system.sh -r $(DEVICE_IP)
 
@@ -112,7 +113,7 @@ endif
 # Dev Release - Prerelease for testing
 # -----------------------------------------------------------------------------
 dev_release: export BUILD_VERSION := $(VERSION_DEV)
-dev_release: git_check_dev test
+dev_release: git_check_dev build
 	@if rclone lsf $(R2_PATH)/$(VERSION_DEV)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION_DEV) already exists in R2"; exit 1; \
 	fi
@@ -140,7 +141,7 @@ dev_release: git_check_dev test
 # Production Release
 # -----------------------------------------------------------------------------
 release: export BUILD_VERSION := $(VERSION)
-release: check_signing_key git_check_dev test
+release: check_signing_key git_check_dev build
 	@if rclone lsf $(R2_PATH)/$(VERSION)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION) already exists in R2"; exit 1; \
 	fi
@@ -178,6 +179,28 @@ release: check_signing_key git_check_dev test
 	@echo "Next: Run 'make bump-version' to prepare for next release cycle"
 
 # -----------------------------------------------------------------------------
+# Production Release Dry Run
+# -----------------------------------------------------------------------------
+release_dry_run: export BUILD_VERSION := $(VERSION)
+release_dry_run: check_signing_key build
+	@echo ""
+	@echo "═══════════════════════════════════════════════════════"
+	@echo "  PRODUCTION Release Dry Run"
+	@echo "═══════════════════════════════════════════════════════"
+	@echo "  Version: $(VERSION)"
+	@echo "  Tag:     release/v$(VERSION)"
+	@echo "  Branch:  $$(git rev-parse --abbrev-ref HEAD)"
+	@echo "  Commit:  $$(git rev-parse --short HEAD)"
+	@echo "  Subject: $$(git log -1 --pretty=%s)"
+	@echo "  Signing: $(SIGNING_KEY_FPR)"
+	@echo "═══════════════════════════════════════════════════════"
+	@echo ""
+	./scripts/release_r2.sh --dry-run --version $(VERSION) --signing-key $(SIGNING_KEY_FPR)
+	./scripts/release_github.sh --dry-run --version $(VERSION)
+	@echo ""
+	@echo "OK: Production release dry run complete: release/v$(VERSION)"
+
+# -----------------------------------------------------------------------------
 # Bump Version
 # -----------------------------------------------------------------------------
 bump-version:
@@ -202,5 +225,6 @@ clean:
 	@echo "Cleaning build artifacts..."
 	sudo rm -rf output/
 	./build.sh clean
+	rm -rf release-artifacts/
 	rm -f buildkit.tar.zst
 	@echo "OK: Clean complete"

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ check_signing_key:
 # -----------------------------------------------------------------------------
 # Build / Flash / Test (dependency chain)
 # -----------------------------------------------------------------------------
-build: clean
+build:
 	./scripts/build_system.sh
 
 check_device:

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -13,29 +13,109 @@ if [ -z "${BUILD_VERSION:-}" ]; then
     export BUILD_VERSION_SOURCE="local-dev"
 fi
 
+stage_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local require_sd_zip="${3:-false}"
+    local stage_dir
+
+    stage_dir=$(system_variant_dir "$sku")
+    mkdir -p "$stage_dir"
+
+    if [ ! -f "$OTA_TAR" ]; then
+        msg_err "Error: $OTA_TAR not found after ${label} build"
+        exit 1
+    fi
+    if [ ! -f "$FULL_IMG" ]; then
+        msg_err "Error: $FULL_IMG not found after ${label} build"
+        exit 1
+    fi
+
+    msg_info "  Staging ${label} system artifacts (${sku})..."
+    cp --reflink=auto "$OTA_TAR" "${stage_dir}/${SYSTEM_TAR_NAME}"
+    cp --reflink=auto "$FULL_IMG" "${stage_dir}/${FULL_IMG_NAME}"
+    sha256sum "${stage_dir}/${SYSTEM_TAR_NAME}" | awk '{print $1}' > "${stage_dir}/${SYSTEM_TAR_NAME}.sha256"
+    sha256sum "${stage_dir}/${FULL_IMG_NAME}" | awk '{print $1}' > "${stage_dir}/${FULL_IMG_NAME}.sha256"
+
+    if [ "$require_sd_zip" = true ]; then
+        if [ ! -f "$SD_IMG_ZIP" ]; then
+            msg_err "Error: $SD_IMG_ZIP not found after ${label} build"
+            exit 1
+        fi
+        cp --reflink=auto "$SD_IMG_ZIP" "${stage_dir}/${SD_IMG_ZIP_NAME}"
+        sha256sum "${stage_dir}/${SD_IMG_ZIP_NAME}" | awk '{print $1}' > "${stage_dir}/${SD_IMG_ZIP_NAME}.sha256"
+    fi
+}
+
+prompt_test_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local confirm
+    local device_ip="${DEVICE_IP:-192.168.1.77}"
+    local device_user="${DEVICE_USER:-root}"
+    local test_args=("-r" "$device_ip" "-u" "$device_user")
+
+    if [ "${PROMPT_VARIANT_TESTS:-1}" != "1" ]; then
+        return 0
+    fi
+
+    echo ""
+    read -p "Test ${label} (${sku}) on a device now? [y/N] " confirm
+    if [ "$confirm" != "y" ]; then
+        msg_warn "Skipping ${label} E2E test"
+        return 0
+    fi
+
+    if [ -z "${JETKVM_REMOTE_HOST:-}" ]; then
+        msg_err "Error: JETKVM_REMOTE_HOST is required to run E2E tests"
+        msg_err "Re-run with JETKVM_REMOTE_HOST=<user@host> and DEVICE_IP=${device_ip} if needed"
+        exit 1
+    fi
+
+    test_args+=("--remote-host" "$JETKVM_REMOTE_HOST")
+    if [ -n "${KVM_DIR:-}" ]; then
+        test_args+=("--kvm-dir" "$KVM_DIR")
+    fi
+    if [ -n "${KVM_BRANCH:-}" ]; then
+        test_args+=("--kvm-branch" "$KVM_BRANCH")
+    fi
+
+    msg_info "  Flashing ${label} build to ${device_user}@${device_ip}..."
+    ./scripts/flash_system.sh -r "$device_ip" -u "$device_user"
+
+    msg_info "  Running ${label} E2E tests..."
+    ./scripts/run_e2e_tests.sh "${test_args[@]}"
+}
+
+build_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local board_config="$3"
+    local require_sd_zip="${4:-false}"
+
+    msg_info "  Running build.sh lunch for ${label} (${sku})..."
+    ./build.sh lunch "$board_config"
+
+    msg_info "  Running build.sh for ${label}..."
+    ./build.sh
+
+    stage_system_variant "$label" "$sku" "$require_sd_zip"
+    prompt_test_system_variant "$label" "$sku"
+}
+
 msg_info ">> Building rv1106-system..."
 cd "$ROOT_DIR"
 
 msg_info "  Updating JetKVM app binary..."
 ./update_app.sh
 
-msg_info "  Running build.sh lunch..."
-./build.sh lunch BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk
+rm -rf "$SYSTEM_RELEASE_DIR"
 
-msg_info "  Running build.sh..."
-./build.sh
+build_system_variant "SDMMC" "$SDMMC_SKU" "$SDMMC_BOARD_CONFIG" true
 
-if [ ! -f "$OTA_TAR" ]; then
-    msg_err "Error: $OTA_TAR not found after build"
-    exit 1
-fi
-if [ ! -f "$FULL_IMG" ]; then
-    msg_err "Error: $FULL_IMG not found after build"
-    exit 1
-fi
+msg_info "  Cleaning build output before EMMC..."
+./build.sh clean
 
-msg_info "  Computing SHA256 checksums..."
-sha256sum "$OTA_TAR" | awk '{print $1}' > "${OTA_TAR}.sha256"
-sha256sum "$FULL_IMG" | awk '{print $1}' > "${FULL_IMG}.sha256"
+build_system_variant "EMMC" "$EMMC_SKU" "$EMMC_BOARD_CONFIG"
 
 msg_ok "OK: Build completed"

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -30,12 +30,16 @@ run_quiet() {
 
     msg_info "  ${label}..."
     msg_info "    log: ${log_file#${ROOT_DIR}/}"
-    if "$@" > "$log_file" 2>&1; then
+    set +e
+    "$@" > "$log_file" 2>&1
+    local status=$?
+    set -e
+
+    if [ "$status" -eq 0 ]; then
         msg_ok "  OK: ${label}"
         return
     fi
 
-    local status=$?
     msg_err "Error: ${label} failed (exit ${status}); log: ${log_file}"
     awk 'BEGIN { IGNORECASE = 1 } /error|failed|permission denied|not found|no such file/ { print }' "$log_file" | tail -n 80 >&2 || true
     msg_err "Last 40 log lines:"

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -13,6 +13,36 @@ if [ -z "${BUILD_VERSION:-}" ]; then
     export BUILD_VERSION_SOURCE="local-dev"
 fi
 
+BUILD_LOG_DIR="${BUILD_LOG_DIR:-${ROOT_DIR}/release-artifacts/logs}"
+
+run_quiet() {
+    local label="$1"
+    shift
+
+    if [ "${VERBOSE_BUILD:-0}" = "1" ]; then
+        "$@"
+        return
+    fi
+
+    mkdir -p "$BUILD_LOG_DIR"
+    local safe_label="${label// /_}"
+    local log_file="${BUILD_LOG_DIR}/$(date -u +%Y%m%d%H%M%S)-${safe_label}.log"
+
+    msg_info "  ${label}..."
+    msg_info "    log: ${log_file#${ROOT_DIR}/}"
+    if "$@" > "$log_file" 2>&1; then
+        msg_ok "  OK: ${label}"
+        return
+    fi
+
+    local status=$?
+    msg_err "Error: ${label} failed (exit ${status}); log: ${log_file}"
+    awk 'BEGIN { IGNORECASE = 1 } /error|failed|permission denied|not found|no such file/ { print }' "$log_file" | tail -n 80 >&2 || true
+    msg_err "Last 40 log lines:"
+    tail -n 40 "$log_file" >&2 || true
+    return "$status"
+}
+
 stage_system_variant() {
     local label="$1"
     local sku="$2"
@@ -93,11 +123,8 @@ build_system_variant() {
     local board_config="$3"
     local require_sd_zip="${4:-false}"
 
-    msg_info "  Running build.sh lunch for ${label} (${sku})..."
-    ./build.sh lunch "$board_config"
-
-    msg_info "  Running build.sh for ${label}..."
-    ./build.sh
+    run_quiet "Selecting ${label} board (${sku})" ./build.sh lunch "$board_config"
+    run_quiet "Building ${label} system image" ./build.sh
 
     stage_system_variant "$label" "$sku" "$require_sd_zip"
     prompt_test_system_variant "$label" "$sku"
@@ -106,8 +133,11 @@ build_system_variant() {
 msg_info ">> Building rv1106-system..."
 cd "$ROOT_DIR"
 
-msg_info "  Updating JetKVM app binary..."
-./update_app.sh
+msg_info "  Cleaning previous build output..."
+sudo rm -rf output/
+run_quiet "Cleaning SDK output" ./build.sh clean
+
+run_quiet "Updating JetKVM app binary" ./update_app.sh
 
 rm -rf "$SYSTEM_RELEASE_DIR"
 
@@ -115,7 +145,7 @@ build_system_variant "SDMMC" "$SDMMC_SKU" "$SDMMC_BOARD_CONFIG" true
 
 msg_info "  Cleaning build output before EMMC..."
 sudo rm -rf output/
-./build.sh clean
+run_quiet "Cleaning SDK output before EMMC" ./build.sh clean
 
 build_system_variant "EMMC" "$EMMC_SKU" "$EMMC_BOARD_CONFIG"
 

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -114,6 +114,7 @@ rm -rf "$SYSTEM_RELEASE_DIR"
 build_system_variant "SDMMC" "$SDMMC_SKU" "$SDMMC_BOARD_CONFIG" true
 
 msg_info "  Cleaning build output before EMMC..."
+sudo rm -rf output/
 ./build.sh clean
 
 build_system_variant "EMMC" "$EMMC_SKU" "$EMMC_BOARD_CONFIG"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -138,5 +138,23 @@ wait_for_device() {
 OUTPUT_IMAGE_DIR="${ROOT_DIR:-$(pwd)}/output/image"
 OTA_TAR_NAME="update_ota.tar"
 FULL_IMG_NAME="update.img"
+SD_IMG_ZIP_NAME="update_sd.img.zip"
 OTA_TAR="${OUTPUT_IMAGE_DIR}/${OTA_TAR_NAME}"
 FULL_IMG="${OUTPUT_IMAGE_DIR}/${FULL_IMG_NAME}"
+SD_IMG_ZIP="${OUTPUT_IMAGE_DIR}/${SD_IMG_ZIP_NAME}"
+
+# -----------------------------------------------------------------------------
+# System release variants
+# -----------------------------------------------------------------------------
+SYSTEM_RELEASE_DIR="${ROOT_DIR:-$(pwd)}/release-artifacts/system"
+SYSTEM_TAR_NAME="system.tar"
+
+EMMC_SKU="jetkvm-v2"
+EMMC_BOARD_CONFIG="BoardConfig_IPC/BoardConfig-EMMC-NONE-RV1106_JETKVM_V2.mk"
+SDMMC_SKU="jetkvm-v2-sdmmc"
+SDMMC_BOARD_CONFIG="BoardConfig_IPC/BoardConfig-SDMMC-NONE-RV1106_JETKVM_V2.mk"
+
+system_variant_dir() {
+    local sku="$1"
+    echo "${SYSTEM_RELEASE_DIR}/${sku}"
+}

--- a/scripts/release_github.sh
+++ b/scripts/release_github.sh
@@ -63,13 +63,14 @@ cd "$ROOT_DIR"
 buildkit="buildkit.tar.zst"
 emmc_dir=$(system_variant_dir "$EMMC_SKU")
 sdmmc_dir=$(system_variant_dir "$SDMMC_SKU")
+github_dir="${ROOT_DIR}/release-artifacts/github"
 github_assets=(
-    "${emmc_dir}/${SYSTEM_TAR_NAME}#${OTA_TAR_NAME}"
-    "${emmc_dir}/${FULL_IMG_NAME}#${FULL_IMG_NAME}"
-    "${sdmmc_dir}/${SYSTEM_TAR_NAME}#update_ota-sdmmc.tar"
-    "${sdmmc_dir}/${FULL_IMG_NAME}#update-sdmmc.img"
-    "${sdmmc_dir}/${SD_IMG_ZIP_NAME}#${SD_IMG_ZIP_NAME}"
-    "${buildkit}#kvm-native-buildkit.tar.zst"
+    "${github_dir}/${OTA_TAR_NAME}"
+    "${github_dir}/${FULL_IMG_NAME}"
+    "${github_dir}/update_ota-sdmmc.tar"
+    "${github_dir}/update-sdmmc.img"
+    "${github_dir}/${SD_IMG_ZIP_NAME}"
+    "${github_dir}/kvm-native-buildkit.tar.zst"
 )
 
 if [ ! -f "$buildkit" ]; then
@@ -77,10 +78,31 @@ if [ ! -f "$buildkit" ]; then
     ./make_buildkit.sh
 fi
 
+stage_github_asset() {
+    local source_path="$1"
+    local asset_name="$2"
+    local dest_path="${github_dir}/${asset_name}"
+
+    if [ ! -f "$source_path" ]; then
+        msg_err "Error: Required file not found: $source_path"
+        msg_err "Run 'make build' first."
+        exit 1
+    fi
+
+    mkdir -p "$github_dir"
+    cp --reflink=auto "$source_path" "$dest_path"
+}
+
+stage_github_asset "${emmc_dir}/${SYSTEM_TAR_NAME}" "$OTA_TAR_NAME"
+stage_github_asset "${emmc_dir}/${FULL_IMG_NAME}" "$FULL_IMG_NAME"
+stage_github_asset "${sdmmc_dir}/${SYSTEM_TAR_NAME}" "update_ota-sdmmc.tar"
+stage_github_asset "${sdmmc_dir}/${FULL_IMG_NAME}" "update-sdmmc.img"
+stage_github_asset "${sdmmc_dir}/${SD_IMG_ZIP_NAME}" "$SD_IMG_ZIP_NAME"
+stage_github_asset "$buildkit" "kvm-native-buildkit.tar.zst"
+
 for asset in "${github_assets[@]}"; do
-    asset_path="${asset%%#*}"
-    if [ ! -f "$asset_path" ]; then
-        msg_err "Error: Required file not found: $asset_path"
+    if [ ! -f "$asset" ]; then
+        msg_err "Error: Required file not found: $asset"
         msg_err "Run 'make build' first."
         exit 1
     fi
@@ -113,9 +135,8 @@ msg_info "  Commit:  $(git rev-parse --short HEAD)"
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Files to upload:"
 for asset in "${github_assets[@]}"; do
-    asset_path="${asset%%#*}"
-    asset_name="${asset##*#}"
-    asset_size=$(du -h "$asset_path" | cut -f1)
+    asset_name=$(basename "$asset")
+    asset_size=$(du -h "$asset" | cut -f1)
     msg_info "    - ${asset_name} (${asset_size})"
 done
 msg_info "═══════════════════════════════════════════════════════"

--- a/scripts/release_github.sh
+++ b/scripts/release_github.sh
@@ -7,15 +7,17 @@ ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 
 BUILD_VERSION=""
 PRERELEASE=false
+DRY_RUN=false
 
 source "${SCRIPT_DIR}/common.sh"
 
 show_help() {
-    echo "Usage: $0 --version <version> [--prerelease]"
+    echo "Usage: $0 --version <version> [--prerelease] [--dry-run]"
     echo
     echo "Options:"
     echo "  --version <version>   Release version (e.g., 0.2.7)"
     echo "  --prerelease          Mark release as prerelease"
+    echo "  --dry-run             Validate and print release inputs without tagging or uploading"
     echo "  --help                Show this help message"
     echo
 }
@@ -28,6 +30,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --prerelease)
             PRERELEASE=true
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=true
             shift
             ;;
         --help)
@@ -47,45 +53,58 @@ if [ -z "$BUILD_VERSION" ]; then
     exit 1
 fi
 
-command -v gh >/dev/null 2>&1 || { msg_err "Error: gh CLI not installed"; exit 1; }
-gh auth status >/dev/null 2>&1 || { msg_err "Error: gh CLI not authenticated. Run 'gh auth login'"; exit 1; }
+if [ "$DRY_RUN" != true ]; then
+    command -v gh >/dev/null 2>&1 || { msg_err "Error: gh CLI not installed"; exit 1; }
+    gh auth status >/dev/null 2>&1 || { msg_err "Error: gh CLI not authenticated. Run 'gh auth login'"; exit 1; }
+fi
 
 cd "$ROOT_DIR"
 
-ota_tar="$OTA_TAR"
-full_img="$FULL_IMG"
 buildkit="buildkit.tar.zst"
-buildkit_name="kvm-native-buildkit.tar.zst"
+emmc_dir=$(system_variant_dir "$EMMC_SKU")
+sdmmc_dir=$(system_variant_dir "$SDMMC_SKU")
+github_assets=(
+    "${emmc_dir}/${SYSTEM_TAR_NAME}#${OTA_TAR_NAME}"
+    "${emmc_dir}/${FULL_IMG_NAME}#${FULL_IMG_NAME}"
+    "${sdmmc_dir}/${SYSTEM_TAR_NAME}#update_ota-sdmmc.tar"
+    "${sdmmc_dir}/${FULL_IMG_NAME}#update-sdmmc.img"
+    "${sdmmc_dir}/${SD_IMG_ZIP_NAME}#${SD_IMG_ZIP_NAME}"
+    "${buildkit}#kvm-native-buildkit.tar.zst"
+)
 
 if [ ! -f "$buildkit" ]; then
     msg_info ">> buildkit.tar.zst not found, creating..."
     ./make_buildkit.sh
 fi
 
-for file in "$ota_tar" "$full_img" "$buildkit"; do
-    if [ ! -f "$file" ]; then
-        msg_err "Error: Required file not found: $file"
+for asset in "${github_assets[@]}"; do
+    asset_path="${asset%%#*}"
+    if [ ! -f "$asset_path" ]; then
+        msg_err "Error: Required file not found: $asset_path"
+        msg_err "Run 'make build' first."
         exit 1
     fi
 done
 
-if gh release view "release/v${BUILD_VERSION}" --repo jetkvm/rv1106-system >/dev/null 2>&1; then
-    msg_err "Error: GitHub release release/v${BUILD_VERSION} already exists"
-    exit 1
-fi
+if [ "$DRY_RUN" != true ]; then
+    if gh release view "release/v${BUILD_VERSION}" --repo jetkvm/rv1106-system >/dev/null 2>&1; then
+        msg_err "Error: GitHub release release/v${BUILD_VERSION} already exists"
+        exit 1
+    fi
 
-if git rev-parse "release/v${BUILD_VERSION}" >/dev/null 2>&1; then
-    msg_err "Error: Git tag release/v${BUILD_VERSION} already exists"
-    exit 1
+    if git rev-parse "release/v${BUILD_VERSION}" >/dev/null 2>&1; then
+        msg_err "Error: Git tag release/v${BUILD_VERSION} already exists"
+        exit 1
+    fi
 fi
-
-ota_size=$(du -h "$ota_tar" | cut -f1)
-img_size=$(du -h "$full_img" | cut -f1)
-kit_size=$(du -h "$buildkit" | cut -f1)
 
 echo ""
 msg_info "═══════════════════════════════════════════════════════"
-msg_info "  GitHub Release"
+if [ "$DRY_RUN" = true ]; then
+    msg_info "  GitHub Release Dry Run"
+else
+    msg_info "  GitHub Release"
+fi
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Version: ${BUILD_VERSION}"
 msg_info "  Tag:     release/v${BUILD_VERSION}"
@@ -93,11 +112,20 @@ msg_info "  Branch:  $(git rev-parse --abbrev-ref HEAD)"
 msg_info "  Commit:  $(git rev-parse --short HEAD)"
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Files to upload:"
-msg_info "    - update_ota.tar    (${ota_size})"
-msg_info "    - update.img        (${img_size})"
-msg_info "    - ${buildkit_name}  (${kit_size})"
+for asset in "${github_assets[@]}"; do
+    asset_path="${asset%%#*}"
+    asset_name="${asset##*#}"
+    asset_size=$(du -h "$asset_path" | cut -f1)
+    msg_info "    - ${asset_name} (${asset_size})"
+done
 msg_info "═══════════════════════════════════════════════════════"
 echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    msg_ok "OK: GitHub dry run complete; skipped tag push and release creation"
+    exit 0
+fi
+
 read -p "These are the inputs for GitHub. Are you sure? [y/N] " confirm
 if [ "$confirm" != "y" ]; then
     msg_warn "GitHub release cancelled."
@@ -109,7 +137,12 @@ git tag "release/v${BUILD_VERSION}"
 git push origin "release/v${BUILD_VERSION}"
 
 msg_info ">> Creating GitHub release..."
-release_args=( "release/v${BUILD_VERSION}" "$ota_tar" "$full_img" "${buildkit}#${buildkit_name}" "--title" "${BUILD_VERSION}" "--generate-notes" )
+release_args=(
+    "release/v${BUILD_VERSION}"
+    "${github_assets[@]}"
+    "--title" "${BUILD_VERSION}"
+    "--generate-notes"
+)
 if [ "$PRERELEASE" = true ]; then
     release_args+=( "--prerelease" )
 fi

--- a/scripts/release_r2.sh
+++ b/scripts/release_r2.sh
@@ -9,17 +9,19 @@ BUILD_VERSION=""
 R2_PATH="${R2_PATH:-r2://jetkvm-update/system}"
 SIGNING_KEY_FPR=""
 UNSIGNED=false
+DRY_RUN=false
 OTA_ROOT_KEY_FPR="AF5A36A993D828FEFE7C18C2D1B9856C26A79E95"
 
 source "${SCRIPT_DIR}/common.sh"
 
 show_help() {
-    echo "Usage: $0 --version <version> (--signing-key <fingerprint> | --unsigned)"
+    echo "Usage: $0 --version <version> (--signing-key <fingerprint> | --unsigned) [--dry-run]"
     echo
     echo "Options:"
     echo "  --version <version>   Release version (e.g., 0.2.7)"
     echo "  --signing-key <fpr>   Sign the OTA payload with the trusted production key"
     echo "  --unsigned            Upload without an OTA signature (dev/prerelease only)"
+    echo "  --dry-run             Sign and validate, but do not upload to R2"
     echo "  --help                Show this help message"
     echo
 }
@@ -77,6 +79,10 @@ while [[ $# -gt 0 ]]; do
             UNSIGNED=true
             shift
             ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
         --help)
             show_help
             exit 0
@@ -108,81 +114,144 @@ if [ -n "$SIGNING_KEY_FPR" ]; then
     validate_signing_key "$SIGNING_KEY_FPR"
 fi
 
-command -v rclone >/dev/null 2>&1 || { msg_err "Error: rclone not installed"; exit 1; }
+if [ "$DRY_RUN" != true ]; then
+    command -v rclone >/dev/null 2>&1 || { msg_err "Error: rclone not installed"; exit 1; }
+fi
 
 cd "$ROOT_DIR"
 
-ota_tar="$OTA_TAR"
-ota_sha="${OTA_TAR}.sha256"
-ota_sig="${OTA_TAR}.sig"
-full_img="$FULL_IMG"
-img_sha="${FULL_IMG}.sha256"
+validate_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local stage_dir
 
-for file in "$ota_tar" "$full_img"; do
-    if [ ! -f "$file" ]; then
-        msg_err "Error: Required file not found: $file"
+    stage_dir=$(system_variant_dir "$sku")
+    for file in \
+        "${stage_dir}/${SYSTEM_TAR_NAME}" \
+        "${stage_dir}/${SYSTEM_TAR_NAME}.sha256" \
+        "${stage_dir}/${FULL_IMG_NAME}" \
+        "${stage_dir}/${FULL_IMG_NAME}.sha256"
+    do
+        if [ ! -f "$file" ]; then
+            msg_err "Error: Required ${label} artifact not found: $file"
+            msg_err "Run 'make build' first."
+            exit 1
+        fi
+    done
+}
+
+sign_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local stage_dir
+    local system_tar
+    local system_sig
+
+    stage_dir=$(system_variant_dir "$sku")
+    system_tar="${stage_dir}/${SYSTEM_TAR_NAME}"
+    system_sig="${system_tar}.sig"
+    rm -f "$system_sig"
+
+    msg_info "  Signing ${label} OTA payload (${sku})..."
+    for attempt in 1 2 3; do
+        if gpg --yes --detach-sign --output "$system_sig" --local-user "$SIGNING_KEY_FPR" "$system_tar"; then
+            break
+        fi
+        rm -f "$system_sig"
+        if [ "$attempt" -eq 3 ]; then
+            msg_err "Error: GPG signing failed after 3 attempts for ${label}"
+            exit 1
+        fi
+        msg_warn "GPG signing failed for ${label} (attempt ${attempt}/3). Please retry."
+    done
+
+    if [ ! -f "$system_sig" ]; then
+        msg_err "Error: Signature file not created: $system_sig"
         exit 1
     fi
-done
+}
 
-if [ ! -f "$ota_sha" ]; then
-    sha256sum "$ota_tar" | awk '{print $1}' > "$ota_sha"
-fi
-if [ ! -f "$img_sha" ]; then
-    sha256sum "$full_img" | awk '{print $1}' > "$img_sha"
-fi
+print_system_variant() {
+    local label="$1"
+    local sku="$2"
+    local stage_dir
+    local system_hash
+    local img_hash
 
-if rclone lsf "${R2_PATH}/${BUILD_VERSION}/" 2>/dev/null | grep -q .; then
-    msg_err "Error: Version ${BUILD_VERSION} already exists in R2"
-    exit 1
+    stage_dir=$(system_variant_dir "$sku")
+    system_hash=$(< "${stage_dir}/${SYSTEM_TAR_NAME}.sha256")
+    img_hash=$(< "${stage_dir}/${FULL_IMG_NAME}.sha256")
+
+    msg_info "    - ${label} (${sku})"
+    msg_info "      ${SYSTEM_TAR_NAME} → skus/${sku}/${SYSTEM_TAR_NAME}"
+    msg_info "      SHA256: ${system_hash}"
+    if [ -n "$SIGNING_KEY_FPR" ]; then
+        msg_info "      Signature: ${stage_dir}/${SYSTEM_TAR_NAME}.sig → skus/${sku}/${SYSTEM_TAR_NAME}.sig"
+    fi
+    msg_info "      ${FULL_IMG_NAME} → skus/${sku}/${FULL_IMG_NAME}"
+    msg_info "      SHA256: ${img_hash}"
+}
+
+upload_system_variant() {
+    local sku="$1"
+    local stage_dir
+    local dest
+
+    stage_dir=$(system_variant_dir "$sku")
+    dest="${R2_PATH}/${BUILD_VERSION}/skus/${sku}"
+
+    rclone copyto --progress "${stage_dir}/${SYSTEM_TAR_NAME}" "${dest}/${SYSTEM_TAR_NAME}"
+    rclone copyto --progress "${stage_dir}/${SYSTEM_TAR_NAME}.sha256" "${dest}/${SYSTEM_TAR_NAME}.sha256"
+    if [ -n "$SIGNING_KEY_FPR" ]; then
+        rclone copyto --progress "${stage_dir}/${SYSTEM_TAR_NAME}.sig" "${dest}/${SYSTEM_TAR_NAME}.sig"
+    fi
+    rclone copyto --progress "${stage_dir}/${FULL_IMG_NAME}" "${dest}/${FULL_IMG_NAME}"
+    rclone copyto --progress "${stage_dir}/${FULL_IMG_NAME}.sha256" "${dest}/${FULL_IMG_NAME}.sha256"
+}
+
+validate_system_variant "SDMMC" "$SDMMC_SKU"
+validate_system_variant "EMMC" "$EMMC_SKU"
+
+if [ "$DRY_RUN" != true ]; then
+    if rclone lsf "${R2_PATH}/${BUILD_VERSION}/" 2>/dev/null | grep -q .; then
+        msg_err "Error: Version ${BUILD_VERSION} already exists in R2"
+        exit 1
+    fi
 fi
 
 if [ -n "$SIGNING_KEY_FPR" ]; then
-    msg_info ">> Signing OTA payload with ${SIGNING_KEY_FPR}..."
+    msg_info ">> Signing OTA payloads with ${SIGNING_KEY_FPR}..."
     read -p "Ensure the YubiKey is inserted and ready, then continue signing? [y/N] " confirm_sign
     if [ "$confirm_sign" != "y" ]; then
         msg_warn "Signing cancelled."
         exit 1
     fi
-    rm -f "$ota_sig"
 
-    for attempt in 1 2 3; do
-        if gpg --yes --detach-sign --output "$ota_sig" --local-user "$SIGNING_KEY_FPR" "$ota_tar"; then
-            break
-        fi
-        rm -f "$ota_sig"
-        if [ "$attempt" -eq 3 ]; then
-            msg_err "Error: GPG signing failed after 3 attempts"
-            exit 1
-        fi
-        msg_warn "GPG signing failed (attempt ${attempt}/3). Please retry."
-    done
-
-    if [ ! -f "$ota_sig" ]; then
-        msg_err "Error: Signature file not created: $ota_sig"
-        exit 1
-    fi
+    sign_system_variant "SDMMC" "$SDMMC_SKU"
+    sign_system_variant "EMMC" "$EMMC_SKU"
 fi
-
-ota_hash=$(cat "$ota_sha")
-img_hash=$(cat "$img_sha")
 
 echo ""
 msg_info "═══════════════════════════════════════════════════════"
-msg_info "  R2 Upload"
+if [ "$DRY_RUN" = true ]; then
+    msg_info "  R2 Upload Dry Run"
+else
+    msg_info "  R2 Upload"
+fi
 msg_info "═══════════════════════════════════════════════════════"
-msg_info "  Destination: ${R2_PATH}/${BUILD_VERSION}/"
+msg_info "  Destination: ${R2_PATH}/${BUILD_VERSION}/skus/<sku>/"
 msg_info "═══════════════════════════════════════════════════════"
 msg_info "  Files to upload:"
-msg_info "    - update_ota.tar     → system.tar"
-msg_info "      SHA256: ${ota_hash}"
-if [ -n "$SIGNING_KEY_FPR" ]; then
-    msg_info "      Signature: ${ota_sig} → system.tar.sig"
-fi
-msg_info "    - update.img         → update.img"
-msg_info "      SHA256: ${img_hash}"
+print_system_variant "SDMMC" "$SDMMC_SKU"
+print_system_variant "EMMC" "$EMMC_SKU"
 msg_info "═══════════════════════════════════════════════════════"
 echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    msg_ok "OK: R2 dry run complete; skipped upload"
+    exit 0
+fi
+
 read -p "The R2 upload is prepared. These are the files. Do you want to continue? [y/N] " confirm
 if [ "$confirm" != "y" ]; then
     msg_warn "R2 upload cancelled."
@@ -190,12 +259,7 @@ if [ "$confirm" != "y" ]; then
 fi
 
 msg_info ">> Uploading to R2..."
-rclone copyto --progress "$ota_tar" "${R2_PATH}/${BUILD_VERSION}/system.tar"
-rclone copyto --progress "$ota_sha" "${R2_PATH}/${BUILD_VERSION}/system.tar.sha256"
-if [ -n "$SIGNING_KEY_FPR" ]; then
-    rclone copyto --progress "$ota_sig" "${R2_PATH}/${BUILD_VERSION}/system.tar.sig"
-fi
-rclone copyto --progress "$full_img" "${R2_PATH}/${BUILD_VERSION}/update.img"
-rclone copyto --progress "$img_sha" "${R2_PATH}/${BUILD_VERSION}/update.img.sha256"
+upload_system_variant "$SDMMC_SKU"
+upload_system_variant "$EMMC_SKU"
 
-msg_ok "OK: Uploaded to R2: ${R2_PATH}/${BUILD_VERSION}/"
+msg_ok "OK: Uploaded to R2: ${R2_PATH}/${BUILD_VERSION}/skus/"


### PR DESCRIPTION
## Summary
- Build and stage both SDMMC and EMMC system artifacts with SKU-specific release paths.
- Upload R2 system artifacts under `system/<version>/skus/<sku>/` while preserving existing EMMC GitHub asset names and adding SD assets.
- Add a production dry-run release path that builds, optionally tests, signs, and validates without uploading or creating GitHub releases.

## Test plan
- `bash -n scripts/common.sh scripts/build_system.sh scripts/release_r2.sh scripts/release_github.sh`
- `make -n flash`
- `make -n dev_release`
- `make -n release SIGNING_KEY_FPR=dummy`
- `make -n release_dry_run SIGNING_KEY_FPR=dummy`
- `git diff --check`
- `npx vitest run test/releases.test.ts` in `../cloud-api`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the build/release pipeline to produce and publish per-SKU artifacts and modifies signing/upload behavior, which can break release automation or artifact consumers if paths/names are wrong. Adds dry-run modes that reduce operational risk but still touch critical release flows.
> 
> **Overview**
> Adds a SKU-aware system release flow: `scripts/build_system.sh` now builds *both* SDMMC and EMMC variants, stages artifacts (plus checksums) under `release-artifacts/system/<sku>/`, and can optionally prompt to flash+run E2E tests per variant.
> 
> Updates release publishing to consume the staged per-SKU artifacts: `scripts/release_r2.sh` uploads to `system/<version>/skus/<sku>/` (signing each SKU’s `system.tar` when enabled) and `scripts/release_github.sh` preserves existing EMMC asset names while adding SDMMC assets. Introduces `make release_dry_run` plus `--dry-run` modes for R2/GitHub scripts to validate/sign without uploading or creating tags/releases, and adds `release-artifacts/` cleanup/ignore rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4f8a79eefc6db9179c8dfd43aa950a02f70620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->