### PR TITLE
feat(release): download per-SKU app binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: [EMMC, SDMMC]
+        include:
+          - board: EMMC
+            sku: jetkvm-v2
+          - board: SDMMC
+            sku: jetkvm-v2-sdmmc
     name: Build (${{ matrix.board }})
     steps:
       - name: Checkout
@@ -40,7 +44,7 @@ jobs:
           echo "BUILD_VERSION_SOURCE=$BUILD_VERSION_SOURCE" >> $GITHUB_ENV
           echo "$BUILD_VERSION" > VERSION
       - name: Update jetkvm_app
-        run: ./update_app.sh
+        run: ./update_app.sh "${{ matrix.sku }}"
       - name: Build
         run: |
           echo "Version: $BUILD_VERSION (from $BUILD_VERSION_SOURCE)"

--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -128,6 +128,7 @@ build_system_variant() {
     local require_sd_zip="${4:-false}"
 
     run_quiet "Selecting ${label} board (${sku})" ./build.sh lunch "$board_config"
+    run_quiet "Updating JetKVM app binary for ${label} (${sku})" ./update_app.sh "$sku"
     run_quiet "Building ${label} system image" ./build.sh
 
     stage_system_variant "$label" "$sku" "$require_sd_zip"
@@ -140,8 +141,6 @@ cd "$ROOT_DIR"
 msg_info "  Cleaning previous build output..."
 sudo rm -rf output/
 run_quiet "Cleaning SDK output" ./build.sh clean
-
-run_quiet "Updating JetKVM app binary" ./update_app.sh
 
 rm -rf "$SYSTEM_RELEASE_DIR"
 

--- a/update_app.sh
+++ b/update_app.sh
@@ -1,22 +1,18 @@
 #!/bin/bash
-set -eE 
-set -x
+set -eE
 
-# Download latest app binary
-curl -L https://api.jetkvm.com/releases/app/latest -o /tmp/jetkvm_app
+SKU="${1:?Error: SKU is required (usage: $0 <sku>)}"
 
-# Verify download completed successfully
-if [ ! -f /tmp/jetkvm_app ]; then
-    echo "Error: Failed to download latest app binary"
+curl -fL "https://api.jetkvm.com/releases/app/latest?sku=${SKU}" -o /tmp/jetkvm_app
+
+if [ ! -s /tmp/jetkvm_app ]; then
+    echo "Error: Failed to download latest app binary for SKU ${SKU}"
     exit 1
 fi
 
-# Make executable
 chmod +x /tmp/jetkvm_app
-
-# Replace existing binary
 mv /tmp/jetkvm_app project/app/jetkvm/jetkvm/bin/jetkvm_app
 
-echo "Successfully updated jetkvm_app to latest version"
+echo "Successfully updated jetkvm_app to latest version for SKU ${SKU}"
 
 rm -rf project/app/jetkvm/out


### PR DESCRIPTION
## Summary

- `update_app.sh` now requires a SKU positional arg and downloads from `https://api.jetkvm.com/releases/app/latest?sku=<sku>` so SDMMC and EMMC builds get the correct app binary.
- `scripts/build_system.sh` runs the download inside each variant build (after `lunch`) instead of once before both, so each image gets the matching SKU's binary.
- CI matrix carries the SKU per board and passes it to `update_app.sh`.

## Test plan

- [x] CI: confirm both `Build (EMMC)` and `Build (SDMMC)` jobs pass and that the `Update jetkvm_app` step downloads the correct SKU per matrix entry.
- [x] Local: `make build` completes and produces `release-artifacts/system/jetkvm-v2/` and `release-artifacts/system/jetkvm-v2-sdmmc/` with their respective app binaries baked in.
- [x] Local: `./update_app.sh` (no args) exits with a clear error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the firmware build/release pipeline and introduces a required SKU argument to `update_app.sh`, which can break CI/local builds if matrix/env wiring is incorrect or the SKU-specific download fails.
> 
> **Overview**
> Ensures EMMC and SDMMC firmware images bake in the correct `jetkvm_app` by making `update_app.sh` require a SKU argument and fetching `latest?sku=<sku>` with stricter download failure handling.
> 
> Updates `scripts/build_system.sh` to run the app download inside each variant build (after `lunch`) instead of once globally, and updates the GitHub Actions build matrix to carry `sku` per `board` and pass it into the update step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8262a9a5eda55b0b2536d3c1776fd1f01248581c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->