### PR TITLE
feat(release): ship update_sd.img.zip as SDMMC recovery artifact

### DIFF
--- a/scripts/build_system.sh
+++ b/scripts/build_system.sh
@@ -50,8 +50,9 @@ run_quiet() {
 stage_system_variant() {
     local label="$1"
     local sku="$2"
-    local require_sd_zip="${3:-false}"
     local stage_dir
+    local recovery_name
+    local recovery_src
 
     stage_dir=$(system_variant_dir "$sku")
     mkdir -p "$stage_dir"
@@ -60,25 +61,24 @@ stage_system_variant() {
         msg_err "Error: $OTA_TAR not found after ${label} build"
         exit 1
     fi
-    if [ ! -f "$FULL_IMG" ]; then
-        msg_err "Error: $FULL_IMG not found after ${label} build"
+
+    # SDMMC's update.img is a packed Rockchip update image, not a raw disk
+    # image, so it can't be written to a microSD card. We ship the dd-able
+    # update_sd.img.zip as the recovery artifact instead; update.img is
+    # still built for SDMMC but deliberately not staged.
+    recovery_name=$(recovery_artifact_for_sku "$sku")
+    recovery_src=$(recovery_source_for_sku "$sku")
+
+    if [ ! -f "$recovery_src" ]; then
+        msg_err "Error: $recovery_src not found after ${label} build"
         exit 1
     fi
 
     msg_info "  Staging ${label} system artifacts (${sku})..."
     cp --reflink=auto "$OTA_TAR" "${stage_dir}/${SYSTEM_TAR_NAME}"
-    cp --reflink=auto "$FULL_IMG" "${stage_dir}/${FULL_IMG_NAME}"
+    cp --reflink=auto "$recovery_src" "${stage_dir}/${recovery_name}"
     sha256sum "${stage_dir}/${SYSTEM_TAR_NAME}" | awk '{print $1}' > "${stage_dir}/${SYSTEM_TAR_NAME}.sha256"
-    sha256sum "${stage_dir}/${FULL_IMG_NAME}" | awk '{print $1}' > "${stage_dir}/${FULL_IMG_NAME}.sha256"
-
-    if [ "$require_sd_zip" = true ]; then
-        if [ ! -f "$SD_IMG_ZIP" ]; then
-            msg_err "Error: $SD_IMG_ZIP not found after ${label} build"
-            exit 1
-        fi
-        cp --reflink=auto "$SD_IMG_ZIP" "${stage_dir}/${SD_IMG_ZIP_NAME}"
-        sha256sum "${stage_dir}/${SD_IMG_ZIP_NAME}" | awk '{print $1}' > "${stage_dir}/${SD_IMG_ZIP_NAME}.sha256"
-    fi
+    sha256sum "${stage_dir}/${recovery_name}" | awk '{print $1}' > "${stage_dir}/${recovery_name}.sha256"
 }
 
 prompt_test_system_variant() {
@@ -125,13 +125,12 @@ build_system_variant() {
     local label="$1"
     local sku="$2"
     local board_config="$3"
-    local require_sd_zip="${4:-false}"
 
     run_quiet "Selecting ${label} board (${sku})" ./build.sh lunch "$board_config"
     run_quiet "Updating JetKVM app binary for ${label} (${sku})" ./update_app.sh "$sku"
     run_quiet "Building ${label} system image" ./build.sh
 
-    stage_system_variant "$label" "$sku" "$require_sd_zip"
+    stage_system_variant "$label" "$sku"
     prompt_test_system_variant "$label" "$sku"
 }
 
@@ -144,7 +143,7 @@ run_quiet "Cleaning SDK output" ./build.sh clean
 
 rm -rf "$SYSTEM_RELEASE_DIR"
 
-build_system_variant "SDMMC" "$SDMMC_SKU" "$SDMMC_BOARD_CONFIG" true
+build_system_variant "SDMMC" "$SDMMC_SKU" "$SDMMC_BOARD_CONFIG"
 
 msg_info "  Cleaning build output before EMMC..."
 sudo rm -rf output/

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -177,5 +177,10 @@ recovery_artifact_for_sku() {
 # Absolute path of the recovery artifact in the build output dir.
 recovery_source_for_sku() {
     local sku="$1"
-    echo "${OUTPUT_IMAGE_DIR}/$(recovery_artifact_for_sku "$sku")"
+    local artifact
+    # Capture separately so an unknown-SKU exit in recovery_artifact_for_sku
+    # (which would otherwise only kill the command-substitution subshell)
+    # actually fails this function.
+    artifact=$(recovery_artifact_for_sku "$sku") || return $?
+    echo "${OUTPUT_IMAGE_DIR}/${artifact}"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -158,3 +158,24 @@ system_variant_dir() {
     local sku="$1"
     echo "${SYSTEM_RELEASE_DIR}/${sku}"
 }
+
+# Recovery artifact filename per SKU (eMMC -> update.img, SDMMC ->
+# update_sd.img.zip). Keep in sync with RECOVERY_ARTIFACT_BY_SKU in
+# cloud-api/src/releases.ts.
+recovery_artifact_for_sku() {
+    local sku="$1"
+    case "$sku" in
+        "$SDMMC_SKU") echo "$SD_IMG_ZIP_NAME" ;;
+        "$EMMC_SKU")  echo "$FULL_IMG_NAME" ;;
+        *)
+            msg_err "Error: no recovery artifact mapped for SKU '${sku}'"
+            exit 1
+            ;;
+    esac
+}
+
+# Absolute path of the recovery artifact in the build output dir.
+recovery_source_for_sku() {
+    local sku="$1"
+    echo "${OUTPUT_IMAGE_DIR}/$(recovery_artifact_for_sku "$sku")"
+}

--- a/scripts/release_github.sh
+++ b/scripts/release_github.sh
@@ -68,7 +68,6 @@ github_assets=(
     "${github_dir}/${OTA_TAR_NAME}"
     "${github_dir}/${FULL_IMG_NAME}"
     "${github_dir}/update_ota-sdmmc.tar"
-    "${github_dir}/update-sdmmc.img"
     "${github_dir}/${SD_IMG_ZIP_NAME}"
     "${github_dir}/kvm-native-buildkit.tar.zst"
 )
@@ -96,7 +95,6 @@ stage_github_asset() {
 stage_github_asset "${emmc_dir}/${SYSTEM_TAR_NAME}" "$OTA_TAR_NAME"
 stage_github_asset "${emmc_dir}/${FULL_IMG_NAME}" "$FULL_IMG_NAME"
 stage_github_asset "${sdmmc_dir}/${SYSTEM_TAR_NAME}" "update_ota-sdmmc.tar"
-stage_github_asset "${sdmmc_dir}/${FULL_IMG_NAME}" "update-sdmmc.img"
 stage_github_asset "${sdmmc_dir}/${SD_IMG_ZIP_NAME}" "$SD_IMG_ZIP_NAME"
 stage_github_asset "$buildkit" "kvm-native-buildkit.tar.zst"
 

--- a/scripts/release_r2.sh
+++ b/scripts/release_r2.sh
@@ -124,13 +124,15 @@ validate_system_variant() {
     local label="$1"
     local sku="$2"
     local stage_dir
+    local recovery_name
 
     stage_dir=$(system_variant_dir "$sku")
+    recovery_name=$(recovery_artifact_for_sku "$sku")
     for file in \
         "${stage_dir}/${SYSTEM_TAR_NAME}" \
         "${stage_dir}/${SYSTEM_TAR_NAME}.sha256" \
-        "${stage_dir}/${FULL_IMG_NAME}" \
-        "${stage_dir}/${FULL_IMG_NAME}.sha256"
+        "${stage_dir}/${recovery_name}" \
+        "${stage_dir}/${recovery_name}.sha256"
     do
         if [ ! -f "$file" ]; then
             msg_err "Error: Required ${label} artifact not found: $file"
@@ -175,12 +177,14 @@ print_system_variant() {
     local label="$1"
     local sku="$2"
     local stage_dir
+    local recovery_name
     local system_hash
-    local img_hash
+    local recovery_hash
 
     stage_dir=$(system_variant_dir "$sku")
+    recovery_name=$(recovery_artifact_for_sku "$sku")
     system_hash=$(< "${stage_dir}/${SYSTEM_TAR_NAME}.sha256")
-    img_hash=$(< "${stage_dir}/${FULL_IMG_NAME}.sha256")
+    recovery_hash=$(< "${stage_dir}/${recovery_name}.sha256")
 
     msg_info "    - ${label} (${sku})"
     msg_info "      ${SYSTEM_TAR_NAME} → skus/${sku}/${SYSTEM_TAR_NAME}"
@@ -188,16 +192,18 @@ print_system_variant() {
     if [ -n "$SIGNING_KEY_FPR" ]; then
         msg_info "      Signature: ${stage_dir}/${SYSTEM_TAR_NAME}.sig → skus/${sku}/${SYSTEM_TAR_NAME}.sig"
     fi
-    msg_info "      ${FULL_IMG_NAME} → skus/${sku}/${FULL_IMG_NAME}"
-    msg_info "      SHA256: ${img_hash}"
+    msg_info "      ${recovery_name} → skus/${sku}/${recovery_name}"
+    msg_info "      SHA256: ${recovery_hash}"
 }
 
 upload_system_variant() {
     local sku="$1"
     local stage_dir
+    local recovery_name
     local dest
 
     stage_dir=$(system_variant_dir "$sku")
+    recovery_name=$(recovery_artifact_for_sku "$sku")
     dest="${R2_PATH}/${BUILD_VERSION}/skus/${sku}"
 
     rclone copyto --progress "${stage_dir}/${SYSTEM_TAR_NAME}" "${dest}/${SYSTEM_TAR_NAME}"
@@ -205,8 +211,8 @@ upload_system_variant() {
     if [ -n "$SIGNING_KEY_FPR" ]; then
         rclone copyto --progress "${stage_dir}/${SYSTEM_TAR_NAME}.sig" "${dest}/${SYSTEM_TAR_NAME}.sig"
     fi
-    rclone copyto --progress "${stage_dir}/${FULL_IMG_NAME}" "${dest}/${FULL_IMG_NAME}"
-    rclone copyto --progress "${stage_dir}/${FULL_IMG_NAME}.sha256" "${dest}/${FULL_IMG_NAME}.sha256"
+    rclone copyto --progress "${stage_dir}/${recovery_name}" "${dest}/${recovery_name}"
+    rclone copyto --progress "${stage_dir}/${recovery_name}.sha256" "${dest}/${recovery_name}.sha256"
 }
 
 validate_system_variant "SDMMC" "$SDMMC_SKU"


### PR DESCRIPTION
Stops shipping the SDMMC `update.img` (a packed Rockchip update image, not a raw disk image, so it can't be written to a microSD) and instead stages, uploads, and attaches `update_sd.img.zip` everywhere SDMMC artifacts go. A `recovery_artifact_for_sku()` helper in `common.sh` keeps the build, R2, and GitHub release scripts agreeing on which file is the per-SKU recovery image, mirroring the cloud-api map being added in a sister PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which recovery artifact gets staged and published for SDMMC, which could break release pipelines or downstream consumers expecting `update.img`. Changes are isolated to build/release scripts and artifact selection logic.
> 
> **Overview**
> Stops staging/publishing SDMMC `update.img` and instead treats `update_sd.img.zip` as the SDMMC *recovery* artifact everywhere release artifacts are prepared (build staging, R2 upload/validation/printing, and GitHub release assets).
> 
> Introduces per-SKU recovery artifact helpers in `scripts/common.sh` (used by build and release scripts) so eMMC continues to ship `update.img` while SDMMC ships `update_sd.img.zip`, with matching SHA256 generation for the selected artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cea00e9c869482d52b5aa93293696c98f07fb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->